### PR TITLE
feat(select): fix mui select in darkmode

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": true,
-  "printWidth": 160
+  "printWidth": 80
 }

--- a/src/v3/RootWrap.tsx
+++ b/src/v3/RootWrap.tsx
@@ -43,7 +43,16 @@ const theme = createTheme({
     },
   },
   breakpoints: {
-    keys: ['mobile', 'mobile400', 'tablet', 'tablet500', 'tablet600', 'tablet688', 'laptop', 'desktop'],
+    keys: [
+      'mobile',
+      'mobile400',
+      'tablet',
+      'tablet500',
+      'tablet600',
+      'tablet688',
+      'laptop',
+      'desktop',
+    ],
     values: {
       mobile: 0,
       mobile400: 400,

--- a/src/v3/components/multi_select/index.tsx
+++ b/src/v3/components/multi_select/index.tsx
@@ -1,4 +1,10 @@
-import { Checkbox, InputLabel, ListItemText, MenuItem, OutlinedInput } from '@mui/material';
+import {
+  Checkbox,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  OutlinedInput,
+} from '@mui/material';
 import { MultiSelectPropsType } from './types';
 import { StyledMultiSelect, StyledFormControl } from './styled';
 
@@ -9,7 +15,16 @@ import { StyledMultiSelect, StyledFormControl } from './styled';
  * @returns A custom select input field.
  */
 const MultiSelect = (props: MultiSelectPropsType) => {
-  const { label = 'Label', value, onChange, required = false, height = 44, fullWidth = true, options = [] } = props;
+  const {
+    label = 'Label',
+    value,
+    onChange,
+    required = false,
+    height = 44,
+    fullWidth = true,
+    options = [],
+    disabled = false,
+  } = props;
   const varHeight = (56 - height) / 2;
 
   return (
@@ -31,6 +46,9 @@ const MultiSelect = (props: MultiSelectPropsType) => {
         height={height}
         varHeight={varHeight}
         sx={props.sx}
+        inputProps={{
+          disabled,
+        }}
       >
         {options.map((name) => (
           <MenuItem key={name} value={name}>

--- a/src/v3/components/multi_select/styled.tsx
+++ b/src/v3/components/multi_select/styled.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { styled } from '@mui/system';
-import { BaseSelectProps, FormControl, OutlinedSelectProps, Select } from '@mui/material';
+import {
+  BaseSelectProps,
+  FormControl,
+  OutlinedSelectProps,
+  Select,
+} from '@mui/material';
 
 type StyledMultiSelectBaseProps = {
   height: number;
@@ -24,6 +29,7 @@ export const StyledMultiSelectBase = styled(Select)<StyledMultiSelectBaseProps>`
   .MuiInputBase-input {
     padding-top: ${({ varHeight }) => `calc(14.5px - ${varHeight}px)`};
     padding-bottom: ${({ varHeight }) => `calc(14.5px - ${varHeight}px)`};
+    color: var(--black);
     flex: 1 0 0;
 
     &.MuiSelect-select {
@@ -50,9 +56,14 @@ export const StyledMultiSelectBase = styled(Select)<StyledMultiSelectBaseProps>`
   }
 `;
 
-export const StyledMultiSelect = styled(({ className, ...props }: StyledMultiSelectBaseProps) => (
-  <StyledMultiSelectBase {...props} MenuProps={{ PaperProps: { className } }} />
-))(({ theme }) => ({
+export const StyledMultiSelect = styled(
+  ({ className, ...props }: StyledMultiSelectBaseProps) => (
+    <StyledMultiSelectBase
+      {...props}
+      MenuProps={{ PaperProps: { className } }}
+    />
+  )
+)(({ theme }) => ({
   background: 'var(--white)',
   backgroundColor: 'var(--white)',
   borderRadius: 'var(--radius-l)',
@@ -105,31 +116,31 @@ type StyledFormControlProps = {
 };
 
 export const StyledFormControl = styled(FormControl)<StyledFormControlProps>`
-  ${({ varHeight }) => ({
-    '.MuiFormLabel-root[data-shrink=false]': { top: `-${varHeight}px` },
-    '.MuiInputLabel-root': {
-      color: 'var(--accent-350)',
-      '&.Mui-focused': {
-        color: 'var(--accent-main)',
-      },
-    },
-    '.MuiOutlinedInput-root': {
-      '& svg': {
-        color: 'var(--accent-350)',
-        boxSizing: 'content-box',
-      },
-      '&.Mui-focused svg': {
-        color: 'var(--black)',
-      },
-      '& fieldset': {
-        border: '1px solid var(--accent-350)',
-      },
-      '&:hover fieldset': {
-        border: '1px solid var(--accent-main)',
-      },
-      '&.Mui-focused fieldset': {
-        border: '1px solid var(--accent-main)',
-      },
-    },
-  })}
+  .MuiFormLabel-root[data-shrink='false'] {
+    top: ${({ varHeight }) => `-${varHeight}px`};
+  }
+  .MuiInputLabel-root {
+    color: var(--accent-350);
+    &.Mui-focused {
+      color: var(--accent-main);
+    }
+  }
+  .MuiOutlinedInput-root {
+    & svg {
+      color: var(--accent-350);
+      boxsizing: content-box;
+    }
+    &.Mui-focused svg {
+      color: var(--black);
+    }
+    & fieldset {
+      border: 1px solid var(--accent-350);
+    }
+    &:hover fieldset {
+      border: 1px solid var(--accent-main);
+    }
+    &.Mui-focused fieldset {
+      border: 1px solid var(--accent-main);
+    }
+  }
 `;

--- a/src/v3/components/multi_select/types.ts
+++ b/src/v3/components/multi_select/types.ts
@@ -20,5 +20,6 @@ export type MultiSelectPropsType = TextFieldProps & {
   height?: number;
   label?: string;
   options?: string[];
+  disabled?: boolean;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };

--- a/src/v3/components/select/index.tsx
+++ b/src/v3/components/select/index.tsx
@@ -9,13 +9,16 @@ import StyledTextField from './styled';
  * @returns A custom select input field.
  */
 const CustomSelect = (props: SelectPropsType) => {
-  const label = props.label || '';
-  const className = props.className || '';
-  const startIcon = props.startIcon || null;
-  const endIcon = props.endIcon || null;
-  const required = props.required || false;
-  const height = props.height || 44;
-  const fullWidth = props.fullWidth ?? true;
+  const {
+    label = '',
+    className = '',
+    startIcon = null,
+    endIcon = null,
+    required = false,
+    height = 44,
+    fullWidth = true,
+    disabled = false,
+  } = props;
 
   const varHeight = (56 - height) / 2;
 
@@ -38,6 +41,7 @@ const CustomSelect = (props: SelectPropsType) => {
         endAdornment: endIcon,
       }}
       inputProps={{
+        disabled,
         MenuProps: {
           PaperProps: {
             sx: (theme: Theme) => ({

--- a/src/v3/components/select/styled.tsx
+++ b/src/v3/components/select/styled.tsx
@@ -23,6 +23,14 @@ const StyledTextField = styled(TextField)<StyledTextFieldProps>((props) => ({
     '&.MuiSelect-select': {
       minHeight: 'unset',
     },
+    '.MuiTypography-root': {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+    '&.Mui-disabled': {
+      '-webkit-text-fill-color': 'var(--black)',
+    },
   },
   '.MuiOutlinedInput-root': {
     borderRadius: 'var(--radius-l)',
@@ -49,14 +57,12 @@ const StyledTextField = styled(TextField)<StyledTextFieldProps>((props) => ({
     '&.Mui-focused': {
       color: 'var(--accent-main)',
     },
+    '&.Mui-disabled': {
+      color: 'var(--accent-350)',
+    },
   },
   '.MuiFormLabel-root[data-shrink="false"]': {
     top: `-${props.varHeight}px`,
-  },
-  '.MuiTypography-root': {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
   },
 }));
 

--- a/src/v3/pages/ministry/auxiliary_pioneer/aps_form.tsx
+++ b/src/v3/pages/ministry/auxiliary_pioneer/aps_form.tsx
@@ -2,7 +2,13 @@ import React, { useState } from 'react';
 import { Trans } from 'react-i18next';
 import { Link } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
-import { DatePicker, MenuItem, Select, TextField, Typography } from '@components/index';
+import {
+  DatePicker,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@components/index';
 import CustomCheckbox from '@components/checkbox';
 import MultiSelect from '@components/multi_select';
 import { MONTHS } from '@constants/index';
@@ -13,7 +19,10 @@ interface APSFormProps {
   setContinuousServiceDesire: (value: boolean) => void;
 }
 
-const AuxiliaryPioneerForm: React.FC<APSFormProps> = ({ continuousServiceDesire, setContinuousServiceDesire }) => {
+const AuxiliaryPioneerForm: React.FC<APSFormProps> = ({
+  continuousServiceDesire,
+  setContinuousServiceDesire,
+}) => {
   const { t } = useAppTranslation();
   const all_months = MONTHS.map((monthKey) => t(monthKey));
 
@@ -53,7 +62,11 @@ const AuxiliaryPioneerForm: React.FC<APSFormProps> = ({ continuousServiceDesire,
           value={continuousServiceDesire ? [] : selectedMonths}
           disabled={continuousServiceDesire}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setSelectedMonths(typeof e.target.value === 'string' ? e.target.value.split(',') : e.target.value);
+            setSelectedMonths(
+              typeof e.target.value === 'string'
+                ? e.target.value.split(',')
+                : e.target.value
+            );
           }}
         />
       </Grid>
@@ -68,14 +81,24 @@ const AuxiliaryPioneerForm: React.FC<APSFormProps> = ({ continuousServiceDesire,
       <Grid mobile={12}>
         <Typography className="body-regular" marginBottom={1}>
           <Trans i18nKey="tr_pioneerApplicationMoral">
-            <Link href="https://www.jw.org/finder?wtlocale=E&docid=202013206" className="h4" color="var(--accent-dark)" underline="none" target="_blank">
+            <Link
+              href="https://www.jw.org/finder?wtlocale=E&docid=202013206"
+              className="h4"
+              color="var(--accent-dark)"
+              underline="none"
+              target="_blank"
+            >
               link
             </Link>
           </Trans>
         </Typography>
       </Grid>
       <Grid mobile={12} tablet688={4} laptop={3}>
-        <DatePicker label={t('tr_selectDate')} value={new Date()} onChange={(e) => console.log('date', e)} />
+        <DatePicker
+          label={t('tr_selectDate')}
+          value={new Date()}
+          onChange={(e) => console.log('date', e)}
+        />
       </Grid>
       <Grid mobile={12} tablet688={8} laptop={9}>
         <TextField

--- a/src/v3/pages/ministry/auxiliary_pioneer/index.tsx
+++ b/src/v3/pages/ministry/auxiliary_pioneer/index.tsx
@@ -17,7 +17,10 @@ const AuxiliaryPioneer = () => {
 
   return (
     <Box sx={{ display: 'flex', gap: '16px', flexDirection: 'column' }}>
-      <PageTitle title={t('tr_applicationAuxiliaryPioneer')} buttons={laptopUp ? <ButtonSubmitApplication /> : null} />
+      <PageTitle
+        title={t('tr_applicationAuxiliaryPioneer')}
+        buttons={laptopUp ? <ButtonSubmitApplication /> : null}
+      />
       <Box
         sx={{
           flexGrow: 1,
@@ -29,12 +32,20 @@ const AuxiliaryPioneer = () => {
         }}
       >
         <Grid container spacing={2}>
-          <APSForm continuousServiceDesire={continuousServiceDesire} setContinuousServiceDesire={setContinuousServiceDesire} />
+          <APSForm
+            continuousServiceDesire={continuousServiceDesire}
+            setContinuousServiceDesire={setContinuousServiceDesire}
+          />
           <Grid mobile={12} laptop={6} paddingRight={4}>
             <Typography className="h4" color="var(--black)" marginTop={2}>
               {t('tr_noteAPSApplication')}
             </Typography>
-            <Typography className="h4" marginTop={2} marginBottom={1} component="div">
+            <Typography
+              className="h4"
+              marginTop={2}
+              marginBottom={1}
+              component="div"
+            >
               <Stack direction="column" gap={1}>
                 <Trans i18nKey="tr_attentionServiceCommittee" />
               </Stack>
@@ -50,7 +61,11 @@ const AuxiliaryPioneer = () => {
                 { name: 'David Offenbarung', role: 'Service overseer' },
                 { name: 'John Netherleed', role: 'Secretary' },
               ].map((member) => (
-                <MemberAccountItem key={member.name} name={member.name} role={member.role} />
+                <MemberAccountItem
+                  key={member.name}
+                  name={member.name}
+                  role={member.role}
+                />
               ))}
             </Box>
           </Grid>
@@ -59,14 +74,22 @@ const AuxiliaryPioneer = () => {
 
       <InfoTip icon={<IconInfo />} color="white" isBig={false}>
         <Trans i18nKey="tr_moreInformationForAP">
-          <Link href="https://hub.jw.org" className="h4" color="var(--accent-dark)" underline="none" target="_blank">
+          <Link
+            href="https://hub.jw.org"
+            className="h4"
+            color="var(--accent-dark)"
+            underline="none"
+            target="_blank"
+          >
             link
           </Link>
         </Trans>
       </InfoTip>
 
       {!laptopUp && (
-        <Box sx={{ display: 'flex', flexDirection: 'column-reverse', gap: '8px' }}>
+        <Box
+          sx={{ display: 'flex', flexDirection: 'column-reverse', gap: '8px' }}
+        >
           <ButtonSubmitApplication />
         </Box>
       )}


### PR DESCRIPTION
# Description

- Fixed dark mode for mui select

> NOTE:
I had a lot of pain 🤕  to work with our `printWidth` prettier configuration on my 28 inch 4k screen. It is impossible for me to work with two tabs side by side and see the code in full, always finding myself manually moving the size of the panels. I would like to fall back to the default one optimal for every type of screen `80` as suggested by the community https://github.com/prettier/prettier/issues/4298. What do you think guys?

Thanks 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
