### PR TITLE
Re-format the Person filters UI

### DIFF
--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -87,7 +87,7 @@ const Tabs = ({ tabs, value, onChange }: CustomTabProps) => {
             ({ label }, index: number): ReactNode => (
               <Tab
                 label={label}
-                key={label}
+                key={index}
                 className={`${valueOfActivePanel === index ? 'h4' : 'body-regular'}`}
                 {...a11yProps(index)}
               />
@@ -98,7 +98,7 @@ const Tabs = ({ tabs, value, onChange }: CustomTabProps) => {
 
       {tabs.map(
         (tab, i: number): ReactNode => (
-          <CustomTabPanel value={valueOfActivePanel} index={i} key={tab.label}>
+          <CustomTabPanel value={valueOfActivePanel} index={i} key={i}>
             {tab.Component}
           </CustomTabPanel>
         )

--- a/src/components/tabs/index.types.ts
+++ b/src/components/tabs/index.types.ts
@@ -32,7 +32,7 @@ export interface CustomTabProps extends TabOwnProps {
     /**
      * The label of the tab.
      */
-    label: string;
+    label: string | React.ReactNode;
 
     /**
      * The component to be rendered in the tab.

--- a/src/features/congregation/publisher_records/GroupPublisherSelector.tsx
+++ b/src/features/congregation/publisher_records/GroupPublisherSelector.tsx
@@ -42,6 +42,7 @@ const GroupAccordion = ({
         expandIcon={<IconExpand color="var(--black)" />}
         sx={{
           minHeight: 'unset !important',
+          padding: '0 ',
           '.MuiAccordionSummary-content': {
             margin: '10px 0 !important',
           },
@@ -51,8 +52,7 @@ const GroupAccordion = ({
       </AccordionSummary>
       <AccordionDetails
         sx={{
-          paddingBottom: '8px',
-          paddingTop: '0',
+          padding: '0 0 8px 0',
         }}
       >
         <Typography>{children}</Typography>
@@ -101,22 +101,24 @@ const PublisherTab = ({ groups }: { groups: TerritoryGroup[] }) => {
           amount: amount,
         })}
       </span>
-      {groups.map((group, index) => (
-        <GroupAccordion
-          expanded={expanded === index}
-          onChange={(_, state) => setExpanded(state ? index : false)}
-          key={index}
-          label={
-            'Group ' + (index + 1) + (group.name ? ' – ' + group.name : '')
-          }
-        >
-          <VerticalFlex sx={{ gap: '8px', marginTop: '8px' }}>
-            {group.members.map((member, index) => (
-              <PublisherCard key={index} person={member} />
-            ))}
-          </VerticalFlex>
-        </GroupAccordion>
-      ))}
+      <VerticalFlex sx={{ gap: '8px' }}>
+        {groups.map((group, index) => (
+          <GroupAccordion
+            expanded={expanded === index}
+            onChange={(_, state) => setExpanded(state ? index : false)}
+            key={index}
+            label={
+              'Group ' + (index + 1) + (group.name ? ' – ' + group.name : '')
+            }
+          >
+            <VerticalFlex sx={{ gap: '8px', marginTop: '8px' }}>
+              {group.members.map((member, index) => (
+                <PublisherCard key={index} person={member} />
+              ))}
+            </VerticalFlex>
+          </GroupAccordion>
+        ))}
+      </VerticalFlex>
     </div>
   );
 };

--- a/src/features/persons/filter/index.tsx
+++ b/src/features/persons/filter/index.tsx
@@ -1,11 +1,47 @@
-import { Box, Collapse } from '@mui/material';
-import { IconExpand } from '@components/icons';
+import { Box } from '@mui/material';
 import Button from '@components/button';
 import Typography from '@components/typography';
 import FilterGroup from './filter_group';
 import { useAppTranslation, useBreakpoints } from '@hooks/index';
 import useFilter from './useFilter';
 import AssignmentGroup from '../assignment_group';
+import Tabs from '@components/tabs';
+
+const TabLabel = ({ label, count }: { label: string; count: number }) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        transform: count === 0 && 'translateX(12px)',
+        transition: 'transform 0.2s',
+      }}
+    >
+      {label}
+      <LabelBadge value={count} />
+    </Box>
+  );
+};
+
+const LabelBadge = ({ value }: { value: number }) => (
+  <Box
+    sx={{
+      backgroundColor: 'var(--accent-150)',
+      borderRadius: 'var(--radius-s)',
+      width: '24px',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      height: '24px',
+      fontSize: '14px',
+      opacity: value === 0 ? 0 : 1,
+      transition: 'opacity 0.2s',
+    }}
+  >
+    {value.toString()}
+  </Box>
+);
 
 const PersonsFilter = () => {
   const { t } = useAppTranslation();
@@ -13,8 +49,6 @@ const PersonsFilter = () => {
   const { tabletDown } = useBreakpoints();
 
   const {
-    isExpanded,
-    handleExpand,
     filters,
     handleClearFilters,
     assignments,
@@ -24,133 +58,132 @@ const PersonsFilter = () => {
     checkedItems,
   } = useFilter();
 
+  const tabs = [
+    {
+      label: (
+        <TabLabel
+          count={filters.length - checkedItems.length}
+          label={t('tr_categories')}
+        />
+      ),
+      Component: (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '16px',
+            flex: 1,
+            width: '100%',
+            minWidth: '120px',
+          }}
+        >
+          {filterGroups.map((group) => (
+            <FilterGroup
+              key={group.name}
+              group={{
+                name: group.name,
+                items: group.items,
+              }}
+            />
+          ))}
+        </Box>
+      ),
+    },
+    {
+      label: (
+        <TabLabel count={checkedItems.length} label={t('tr_assignments')} />
+      ),
+      Component: (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '8px',
+            flex: 1,
+            width: '100%',
+            minWidth: '150px',
+          }}
+        >
+          <Typography className="body-small-semibold" color="var(--grey-350)">
+            {t('tr_assignments')}
+          </Typography>
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(2, 1fr)',
+              gap: '16px',
+              flexWrap: 'wrap',
+            }}
+          >
+            {assignments.map((assignment) => (
+              <AssignmentGroup
+                key={assignment.id}
+                id={assignment.id}
+                header={assignment.header}
+                color={assignment.color}
+                items={assignment.items}
+                onHeaderChange={handleToggleGroup}
+                onItemChange={handleToggleAssignment}
+                checkedItems={checkedItems}
+                male={true}
+              />
+            ))}
+          </Box>
+        </Box>
+      ),
+    },
+  ];
+
   return (
-    <Box
-      sx={{
-        border: '1px solid var(--accent-350)',
-        padding: '16px',
-        borderRadius: 'var(--radius-l)',
-      }}
-    >
+    <Box>
       <Box
         sx={{
           display: 'flex',
           alignItems: 'center',
-          gap: '24px',
-          justifyContent: 'space-between',
-          cursor: 'pointer',
+          gap: '8px',
+          flexWrap: 'wrap',
         }}
-        onClick={handleExpand}
       >
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            flexWrap: 'wrap',
-          }}
-        >
-          <Typography className="h4">{t('tr_filters')}</Typography>
-          {filters.length > 0 && (
-            <Box
-              sx={{
-                borderRadius: 'var(--radius-s)',
-                padding: '4px 8px',
-                backgroundColor: 'var(--accent-200)',
-              }}
-            >
-              <Typography className="label-small-medium">
-                {t('tr_amountApplied', { amount: filters.length })}
-              </Typography>
-            </Box>
-          )}
-        </Box>
-
-        <IconExpand
-          color="var(--black)"
-          sx={{
-            transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-            transition: 'transform 0.3s',
-          }}
-        />
-      </Box>
-
-      <Collapse in={isExpanded} timeout="auto" unmountOnExit>
-        <Box
-          sx={{
-            display: 'flex',
-            gap: '16px',
-            flexWrap: 'wrap',
-            marginTop: '16px',
-            justifyContent: 'space-between',
-            flexDirection: tabletDown ? 'column' : 'row',
-          }}
-        >
+        <Typography className="h4">{t('tr_filters')}</Typography>
+        {filters.length > 0 && (
           <Box
             sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '16px',
-              flex: 1,
-              width: '100%',
-              minWidth: '120px',
+              borderRadius: 'var(--radius-s)',
+              padding: '4px 8px',
+              backgroundColor: 'var(--accent-200)',
             }}
           >
-            {filterGroups.map((group) => (
-              <FilterGroup
-                key={group.name}
-                group={{
-                  name: group.name,
-                  items: group.items,
-                }}
-              />
-            ))}
-          </Box>
-
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '8px',
-              flex: 1,
-              width: '100%',
-              minWidth: '150px',
-            }}
-          >
-            <Typography className="body-small-semibold" color="var(--grey-350)">
-              {t('tr_assignments')}
+            <Typography className="label-small-medium">
+              {t('tr_amountApplied', { amount: filters.length })}
             </Typography>
-            <Box sx={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
-              {assignments.map((assignment) => (
-                <AssignmentGroup
-                  key={assignment.id}
-                  id={assignment.id}
-                  header={assignment.header}
-                  color={assignment.color}
-                  items={assignment.items}
-                  onHeaderChange={handleToggleGroup}
-                  onItemChange={handleToggleAssignment}
-                  checkedItems={checkedItems}
-                  male={true}
-                />
-              ))}
-            </Box>
           </Box>
-        </Box>
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginTop: '8px',
-            height: '48px',
-          }}
-        >
-          <Button variant="secondary" onClick={handleClearFilters}>
-            {t('tr_clearAll')}
-          </Button>
-        </Box>
-      </Collapse>
+        )}
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: '16px',
+          flexWrap: 'wrap',
+          marginTop: '16px',
+          justifyContent: 'space-between',
+          flexDirection: tabletDown ? 'column' : 'row',
+        }}
+      >
+        <Tabs tabs={tabs} />
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginTop: '8px',
+          height: '48px',
+        }}
+      >
+        <Button variant="secondary" onClick={handleClearFilters}>
+          {t('tr_clearAll')}
+        </Button>
+      </Box>
     </Box>
   );
 };

--- a/src/features/persons/filter/useFilter.tsx
+++ b/src/features/persons/filter/useFilter.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { personsFiltersKeyState, personsTabState } from '@states/persons';
 import { setPersonsFiltersKey } from '@services/recoil/persons';
@@ -16,8 +16,6 @@ const useFilter = () => {
   const checkedItems = filters.filter(
     (record) => typeof record === 'number'
   ) as number[];
-
-  const [isExpanded, setIsExpanded] = useState(false);
 
   const assignments = useMemo(() => {
     return [
@@ -161,10 +159,6 @@ const useFilter = () => {
     ];
   }, [t]);
 
-  const handleExpand = () => {
-    setIsExpanded((prev) => !prev);
-  };
-
   const handleClearFilters = async () => {
     await setPersonsFiltersKey([]);
 
@@ -221,8 +215,6 @@ const useFilter = () => {
   };
 
   return {
-    isExpanded,
-    handleExpand,
     filters,
     handleClearFilters,
     handleToggleGroup,

--- a/src/pages/persons/all_persons/index.tsx
+++ b/src/pages/persons/all_persons/index.tsx
@@ -1,13 +1,21 @@
 import { Badge, Box } from '@mui/material';
 import { Button, PageTitle } from '@components/index';
-import { IconAddPerson, IconDownload } from '@components/icons';
+import {
+  IconAddPerson,
+  IconDownload,
+  IconPanelClose,
+  IconPanelOpen,
+} from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { PersonsFilter, PersonsList, PersonsSearch } from '@features/index';
 import { isDemo } from '@constants/index';
 import useAllPersons from './useAllPersons';
+import { useState } from 'react';
 
 const PersonsAll = () => {
   const { t } = useAppTranslation();
+
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
 
   const { handlePersonAdd, handleGetDummyPersons } = useAllPersons();
 
@@ -45,19 +53,61 @@ const PersonsAll = () => {
 
       <Box
         sx={{
-          backgroundColor: 'var(--white)',
-          border: '1px solid var(--accent-300)',
-          borderRadius: 'var(--radius-xl)',
-          padding: '16px',
           display: 'flex',
           gap: '16px',
-          flexDirection: 'column',
+          alignItems: 'flex-start',
         }}
       >
-        <PersonsSearch />
-        <PersonsFilter />
+        <Box
+          sx={{
+            backgroundColor: 'var(--white)',
+            border: '1px solid var(--accent-300)',
+            flexGrow: 1,
+            borderRadius: 'var(--radius-xl)',
+            padding: '16px',
+            display: 'flex',
+            gap: '16px',
+            flexDirection: 'column',
+          }}
+        >
+          <Box sx={{ display: 'flex', gap: '16px' }}>
+            <PersonsSearch />
+            <Button
+              variant="secondary"
+              onClick={() => setIsPanelOpen(!isPanelOpen)}
+              endIcon={isPanelOpen ? <IconPanelOpen /> : <IconPanelClose />}
+            >
+              {t('tr_filters')}
+            </Button>
+          </Box>
 
-        <PersonsList />
+          <PersonsList />
+        </Box>
+
+        {isPanelOpen && (
+          <Box
+            sx={(theme) => ({
+              backgroundColor: 'var(--white)',
+              border: '1px solid var(--accent-300)',
+              borderRadius: 'var(--radius-xl)',
+              padding: '16px',
+              [theme.breakpoints.up(900)]: {
+                minWidth: '300px',
+                maxWidth: '300px',
+              },
+              [theme.breakpoints.up(1100)]: {
+                minWidth: '400px',
+                maxWidth: '400px',
+              },
+              [theme.breakpoints.up(1400)]: {
+                minWidth: '580px',
+                maxWidth: '580px',
+              },
+            })}
+          >
+            <PersonsFilter />
+          </Box>
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
Re format the persons filters page, that include modifying the custom tab component to accept ReactNode as label instead of only string. (Used to render a badge)

Minor change : I fixed the Publishers record page paddings and alignments 