### PR TITLE
Contribution opportunities link change

### DIFF
--- a/src/features/support/useSupport.tsx
+++ b/src/features/support/useSupport.tsx
@@ -14,7 +14,7 @@ const useSupport = () => {
 
   const handleOpenDoc = () => {
     window.open(
-      `https://github.com/sws2apps/organized-app/blob/main/CONTRIBUTING.md`,
+      `https://guide.organized-app.com/how-to-support/contribute`,
       '_blank'
     );
   };


### PR DESCRIPTION
# Description

Updated the "How to Contribute" button link in the Support popup. It now redirects users to the guide site for the Organised app.

Fixes # (issue)

Since we now have a dedicated site with detailed guides for the Organised app, the "How to Contribute" button was updated to redirect users there. Previously, the button directed people to the guide on GitHub.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
