### PR TITLE
Increased width for circuit number field

### DIFF
--- a/src/features/congregation/settings/congregation_basic/index.tsx
+++ b/src/features/congregation/settings/congregation_basic/index.tsx
@@ -60,7 +60,7 @@ const CongregationBasic = () => {
           onChange={(e) => handleCircuitChange(e.target.value)}
           onKeyUp={handleCircuitSave}
           slotProps={{ input: { readOnly: !isAdmin } }}
-          sx={{ width: tabletUp ? '120px' : '100%' }}
+          sx={{ width: tabletUp ? '160px' : '100%' }}
         />
       </Box>
 


### PR DESCRIPTION
# Description

Increase the width of the field for circuit number in congregation settings to better fit not only short numbers (like 135 or 2515), but also circuits with words included (e.g. London 1B).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
