### PR TITLE
feat(components): change svg loader to MUI CircularProgress for better loading UX

### DIFF
--- a/src/components/congregation_selector/index.tsx
+++ b/src/components/congregation_selector/index.tsx
@@ -1,11 +1,12 @@
 import { Box, createFilterOptions } from '@mui/material';
-import { IconCongregation, IconLoading, IconSearch } from '@icons/index';
+import { IconCongregation, IconSearch } from '@icons/index';
 import { CongregationResponseType } from '@definition/api';
 import { useAppTranslation } from '@hooks/index';
 import { CongregationSelectorType } from './index.types';
 import AutoComplete from '@components/autocomplete';
 import Typography from '@components/typography';
 import useCongregation from './useCongregation';
+import WaitingLoader from '@components/waiting_loader';
 
 const filter = createFilterOptions<CongregationResponseType>({ trim: true });
 
@@ -98,7 +99,11 @@ const CongregationSelector = ({
       }
       endIcon={
         freeSolo && isLoading ? (
-          <IconLoading color="var(--accent-350)" />
+          <WaitingLoader
+            size={24}
+            color="var(--accent-350)"
+            variant="standard"
+          />
         ) : (
           <IconSearch color={value ? 'var(--black)' : 'var(--accent-350)'} />
         )

--- a/src/components/loading/index.tsx
+++ b/src/components/loading/index.tsx
@@ -1,9 +1,9 @@
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { Container } from './index.styles';
 import { AppLoadingType } from './index.types';
 import LottieLoader from '@components/lottie_loader';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 /**
  * Component for displaying a loading indicator.
  * @returns JSX element for the AppLoading component.
@@ -18,7 +18,11 @@ const AppLoading = ({ text, sx, type = 'circular' }: AppLoadingType) => {
       {type === 'lottie' && <LottieLoader />}
 
       {type === 'circular' && (
-        <IconLoading color="var(--accent-main)" width={72} height={72} />
+        <WaitingLoader
+          size={72}
+          color={'var(--accent-main)'}
+          variant="standard"
+        />
       )}
 
       <Typography align="center" className="h4" color="var(--accent-main)">

--- a/src/components/waiting_loader/index.tsx
+++ b/src/components/waiting_loader/index.tsx
@@ -1,5 +1,4 @@
-import { Box, SxProps, Theme } from '@mui/material';
-import { IconLoading } from '@components/icons';
+import { Box, CircularProgress, SxProps, Theme } from '@mui/material';
 import { VariantProps } from './index.types';
 import LottieLoader from '@components/lottie_loader';
 
@@ -12,16 +11,19 @@ const WaitingLoader = ({
   variant = 'fixed',
   size,
   type = 'circular',
+  color = 'var(--accent-dark)',
 }: VariantProps) => {
   let sx: SxProps<Theme> = {};
 
-  if (variant === 'fixed') {
+  if (variant === 'fixed' && type !== 'circular') {
     sx = {
       position: 'absolute',
       top: '50%',
       margin: 'auto',
     };
   }
+
+  const circularLoaderSize = size - 5;
 
   return (
     <Box
@@ -38,7 +40,16 @@ const WaitingLoader = ({
         {type === 'lottie' && <LottieLoader size={size} />}
 
         {type === 'circular' && (
-          <IconLoading width={size} height={size} color="var(--accent-dark)" />
+          <CircularProgress
+            size={circularLoaderSize}
+            sx={{
+              color: color,
+              '& svg': {
+                width: circularLoaderSize,
+                height: circularLoaderSize,
+              },
+            }}
+          />
         )}
       </Box>
     </Box>

--- a/src/components/waiting_loader/index.types.ts
+++ b/src/components/waiting_loader/index.types.ts
@@ -15,4 +15,6 @@ export type VariantProps = {
   size?: number;
 
   type?: 'circular' | 'lottie';
+
+  color?: string;
 };

--- a/src/features/app_start/pocket/signup/index.tsx
+++ b/src/features/app_start/pocket/signup/index.tsx
@@ -1,11 +1,12 @@
 import { Box } from '@mui/material';
-import { IconError, IconLoading } from '@icons/index';
+import { IconError } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import useSignup from './useSignup';
 import Button from '@components/button';
 import InfoMessage from '@components/info-message';
 import PageHeader from '@features/app_start/shared/page_header';
 import TextField from '@components/textfield';
+import WaitingLoader from '@components/waiting_loader';
 
 const PocketSignUp = () => {
   const { t } = useAppTranslation();
@@ -56,7 +57,13 @@ const PocketSignUp = () => {
             onClick={handleValidate}
             sx={{ padding: '8px 32px', minHeight: '44px' }}
             startIcon={
-              isProcessing ? <IconLoading width={22} height={22} /> : null
+              isProcessing ? (
+                <WaitingLoader
+                  size={22}
+                  color="var(--black)"
+                  variant="standard"
+                />
+              ) : null
             }
           >
             {t('tr_activate')}

--- a/src/features/app_start/vip/congregation_create/congregation_access_code/index.tsx
+++ b/src/features/app_start/vip/congregation_create/congregation_access_code/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { IconCongregationAccess, IconError, IconLoading } from '@icons/index';
+import { IconCongregationAccess, IconError } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import useCongregationAccessCode from './useCongregationAccessCode';
 import Button from '@components/button';
@@ -9,6 +9,7 @@ import Markup from '@components/text_markup';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
 import VipInfoTip from '@features/app_start/vip/vip_info_tip';
+import WaitingLoader from '@components/waiting_loader';
 
 const CongregationAccessCode = () => {
   const { t } = useAppTranslation();
@@ -156,7 +157,13 @@ const CongregationAccessCode = () => {
             sx={{ width: '100%' }}
             onClick={handleSetAccessCode}
             startIcon={
-              isProcessing ? <IconLoading width={22} height={22} /> : null
+              isProcessing ? (
+                <WaitingLoader
+                  size={22}
+                  color="var(--black)"
+                  variant="standard"
+                />
+              ) : null
             }
             disabled={btnActionDisabled}
           >

--- a/src/features/app_start/vip/congregation_create/congregation_details/index.tsx
+++ b/src/features/app_start/vip/congregation_create/congregation_details/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { IconAccount, IconError, IconLoading } from '@icons/index';
+import { IconAccount, IconError } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import useCongregationDetails from './useCongregationDetails';
 import Button from '@components/button';
@@ -9,6 +9,7 @@ import CountrySelector from '@components/country_selector';
 import InfoMessage from '@components/info-message';
 import TextField from '@components/textfield';
 import VipInfoTip from '@features/app_start/vip/vip_info_tip';
+import WaitingLoader from '@components/waiting_loader';
 
 const CongregationDetails = () => {
   const { t } = useAppTranslation();
@@ -111,7 +112,13 @@ const CongregationDetails = () => {
             onClick={handleCongregationAction}
             sx={{ width: '100%' }}
             startIcon={
-              isProcessing ? <IconLoading width={22} height={22} /> : null
+              isProcessing ? (
+                <WaitingLoader
+                  size={22}
+                  color="var(--black)"
+                  variant="standard"
+                />
+              ) : null
             }
           >
             {t('tr_createCongregation')}

--- a/src/features/app_start/vip/congregation_create/congregation_master_key/index.tsx
+++ b/src/features/app_start/vip/congregation_create/congregation_master_key/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { IconEncryptionKey, IconError, IconLoading } from '@icons/index';
+import { IconEncryptionKey, IconError } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import useCongregationMasterKey from './useCongregationMasterKey';
 import Button from '@components/button';
@@ -8,6 +8,7 @@ import InfoMessage from '@components/info-message';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
 import Markup from '@components/text_markup';
+import WaitingLoader from '@components/waiting_loader';
 
 const CongregationMasterKey = () => {
   const { t } = useAppTranslation();
@@ -155,7 +156,13 @@ const CongregationMasterKey = () => {
             sx={{ width: '100%' }}
             onClick={handleSetMasterKey}
             startIcon={
-              isProcessing ? <IconLoading width={22} height={22} /> : null
+              isProcessing ? (
+                <WaitingLoader
+                  size={22}
+                  color="var(--black)"
+                  variant="standard"
+                />
+              ) : null
             }
             disabled={btnActionDisabled}
           >

--- a/src/features/app_start/vip/congregation_encryption/congregation_access_code/index.tsx
+++ b/src/features/app_start/vip/congregation_encryption/congregation_access_code/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { IconCongregationAccess, IconError, IconLoading } from '@icons/index';
+import { IconCongregationAccess, IconError } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import useCongregationAccessCode from './useCongregationAccessCode';
 import PageHeader from '@features/app_start/shared/page_header';
@@ -86,7 +86,13 @@ const CongregationAccessCode = () => {
                 sx={{ width: '100%' }}
                 onClick={handleValidateAccessCode}
                 startIcon={
-                  isProcessing ? <IconLoading width={22} height={22} /> : null
+                  isProcessing ? (
+                    <WaitingLoader
+                      size={22}
+                      color="var(--black)"
+                      variant="standard"
+                    />
+                  ) : null
                 }
                 disabled={btnActionDisabled}
               >

--- a/src/features/app_start/vip/congregation_encryption/congregation_master_key/index.tsx
+++ b/src/features/app_start/vip/congregation_encryption/congregation_master_key/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { IconEncryptionKey, IconError, IconLoading } from '@icons/index';
+import { IconEncryptionKey, IconError } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import useCongregationMasterKey from './useCongregationMasterKey';
 import Button from '@components/button';
@@ -86,7 +86,13 @@ const CongregationEncryption = () => {
                 sx={{ width: '100%' }}
                 onClick={handleValidateMasterKey}
                 startIcon={
-                  isProcessing ? <IconLoading width={22} height={22} /> : null
+                  isProcessing ? (
+                    <WaitingLoader
+                      size={22}
+                      color="var(--black)"
+                      variant="standard"
+                    />
+                  ) : null
                 }
                 disabled={btnActionDisabled}
               >

--- a/src/features/app_start/vip/email_link_authentication/index.tsx
+++ b/src/features/app_start/vip/email_link_authentication/index.tsx
@@ -1,10 +1,11 @@
 import { Box } from '@mui/material';
 import Button from '@components/button';
 import InfoMessage from '@components/info-message';
-import { IconError, IconLoading } from '@icons/index';
+import { IconError } from '@icons/index';
 import PageHeader from '@features/app_start/shared/page_header';
 import useAppTranslation from '@hooks/useAppTranslation';
 import useEmailLinkAuth from './useEmailLinkAuth';
+import WaitingLoader from '@components/waiting_loader';
 
 const EmailLinkAuthentication = () => {
   const { t } = useAppTranslation();
@@ -42,7 +43,13 @@ const EmailLinkAuthentication = () => {
             onClick={completeEmailAuth}
             sx={{ padding: '8px 32px', minHeight: '44px' }}
             startIcon={
-              isProcessing ? <IconLoading width={22} height={22} /> : null
+              isProcessing ? (
+                <WaitingLoader
+                  size={22}
+                  color="var(--black)"
+                  variant="standard"
+                />
+              ) : null
             }
           >
             {t('tr_login')}

--- a/src/features/app_start/vip/oauth/button_base/index.tsx
+++ b/src/features/app_start/vip/oauth/button_base/index.tsx
@@ -1,8 +1,8 @@
 import { Box, Button } from '@mui/material';
-import { IconLoading } from '@icons/index';
 import { OAuthButtonBaseProps } from './index.types';
 import useButtonBase from './useButtonBase';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const OAuthButtonBase = (props: OAuthButtonBaseProps) => {
   const { logo, text, provider } = props;
@@ -42,7 +42,7 @@ const OAuthButtonBase = (props: OAuthButtonBaseProps) => {
           {text}
         </Typography>
         {isAuthProcessing && currentProvider === provider?.providerId && (
-          <IconLoading width={22} height={22} color="var(--black)" />
+          <WaitingLoader size={17} color="var(--black)" variant="standard" />
         )}
       </Box>
     </Button>

--- a/src/features/app_start/vip/oauth/email/index.tsx
+++ b/src/features/app_start/vip/oauth/email/index.tsx
@@ -1,10 +1,10 @@
 import { Badge, Box, Link, Stack } from '@mui/material';
-import { IconLoading } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import useOAuthEmail from './useEmail';
 import Button from '@components/button';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const OAuthEmail = () => {
   const { t } = useAppTranslation();
@@ -32,7 +32,11 @@ const OAuthEmail = () => {
         disabled={userTmpEmail.length === 0}
         onClick={handleSendLink}
         sx={{ padding: '8px 32px', minHeight: '44px' }}
-        startIcon={isProcessing ? <IconLoading width={22} height={22} /> : null}
+        startIcon={
+          isProcessing ? (
+            <WaitingLoader size={17} color="var(--black)" variant="standard" />
+          ) : null
+        }
       >
         {t('tr_sendLink')}
       </Button>

--- a/src/features/congregation/app_access/user_add/person_select/index.tsx
+++ b/src/features/congregation/app_access/user_add/person_select/index.tsx
@@ -7,7 +7,8 @@ import Button from '@components/button';
 import Radio from '@components/radio';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
-import { IconError, IconLoading } from '@components/icons';
+import { IconError } from '@components/icons';
+import WaitingLoader from '@components/waiting_loader';
 
 const PersonSelect = (props: PersonSelectType) => {
   const { t } = useAppTranslation();
@@ -127,7 +128,9 @@ const PersonSelect = (props: PersonSelectType) => {
         <Button
           variant="main"
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
           onClick={handleRunAction}
         >
           {userType === 'baptized' && !searchStatus

--- a/src/features/congregation/app_access/user_details/delete_user/index.tsx
+++ b/src/features/congregation/app_access/user_details/delete_user/index.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { DeleteUserType } from './index.types';
 import useDeleteUser from './useDeleteUser';
@@ -7,6 +6,7 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import Typography from '@components/typography';
 import Markup from '@components/text_markup';
+import WaitingLoader from '@components/waiting_loader';
 
 const DeleteUser = ({ open, onClose, user }: DeleteUserType) => {
   const { t } = useAppTranslation();
@@ -37,7 +37,9 @@ const DeleteUser = ({ open, onClose, user }: DeleteUserType) => {
           variant="main"
           color="red"
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
           onClick={handleDeleteUser}
         >
           {t('tr_delete')}

--- a/src/features/congregation/app_access/user_details/invitation_code/delete_code/index.tsx
+++ b/src/features/congregation/app_access/user_details/invitation_code/delete_code/index.tsx
@@ -1,11 +1,11 @@
 import { Box } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { DeleteCodeType } from './index.types';
 import useDeleteCode from './useDeleteCode';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const DeleteCode = ({ open, onClose, user }: DeleteCodeType) => {
   const { t } = useAppTranslation();
@@ -34,7 +34,9 @@ const DeleteCode = ({ open, onClose, user }: DeleteCodeType) => {
           variant="main"
           color="red"
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
           onClick={handleDeleteCode}
         >
           {t('tr_delete')}

--- a/src/features/congregation/app_access/user_details/invitation_code/index.tsx
+++ b/src/features/congregation/app_access/user_details/invitation_code/index.tsx
@@ -1,5 +1,5 @@
 import { Box, InputAdornment } from '@mui/material';
-import { IconCopy, IconInvite, IconLoading, IconSync } from '@components/icons';
+import { IconCopy, IconInvite, IconSync } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { DetailsContainer } from '../shared_styles';
 import { copyToClipboard } from '@utils/common';
@@ -10,6 +10,7 @@ import IconButton from '@components/icon_button';
 import Markup from '@components/text_markup';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const InvitationCode = () => {
   const { t } = useAppTranslation();
@@ -122,7 +123,7 @@ const InvitationCode = () => {
           variant="tertiary"
           startIcon={
             isProcessing ? (
-              <IconLoading />
+              <WaitingLoader size={22} variant="standard" />
             ) : (
               <IconInvite color="var(--accent-dark)" />
             )

--- a/src/features/congregation/app_access/user_details/profile_settings/index.tsx
+++ b/src/features/congregation/app_access/user_details/profile_settings/index.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { DetailsContainer } from '../shared_styles';
 import { UsersOption } from './index.types';
 import { useAppTranslation } from '@hooks/index';
@@ -10,6 +9,7 @@ import AutocompleteMultiple from '@components/autocomplete_multiple';
 import Divider from '@components/divider';
 import MiniChip from '@components/mini_chip';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const ProfileSettings = () => {
   const { t } = useAppTranslation();
@@ -39,7 +39,9 @@ const ProfileSettings = () => {
           <Typography className="h2" color={'var(--black)'}>
             {t('tr_profileSettings')}
           </Typography>
-          {isProcessing && <IconLoading color="var(--black)" />}
+          {isProcessing && (
+            <WaitingLoader size={24} color="var(--black)" variant="standard" />
+          )}
         </Box>
 
         <Autocomplete

--- a/src/features/congregation/app_access/user_details/user_rights/index.tsx
+++ b/src/features/congregation/app_access/user_details/user_rights/index.tsx
@@ -1,12 +1,13 @@
 import { Box } from '@mui/material';
 import { DetailsContainer } from '../shared_styles';
-import { IconInfo, IconLoading } from '@components/icons';
+import { IconInfo } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import useUserDetails from '../useUserDetails';
 import Markup from '@components/text_markup';
 import Typography from '@components/typography';
 import UserAdditionalRights from '../user_additional_rights';
 import UserMainRoles from '../user_main_roles';
+import WaitingLoader from '@components/waiting_loader';
 
 const UserRights = () => {
   const { t } = useAppTranslation();
@@ -27,7 +28,9 @@ const UserRights = () => {
             {t('tr_userRights')}
           </Typography>
 
-          {isProcessing && <IconLoading color="var(--black)" />}
+          {isProcessing && (
+            <WaitingLoader size={24} color="var(--black)" variant="standard" />
+          )}
         </Box>
 
         <Box

--- a/src/features/congregation/field_service_groups/export_groups/index.tsx
+++ b/src/features/congregation/field_service_groups/export_groups/index.tsx
@@ -14,7 +14,7 @@ const ExportGroups = () => {
       variant="secondary"
       onClick={handleExport}
       startIcon={
-        !isProcessing ? (
+        isProcessing ? (
           <WaitingLoader variant="standard" size={20} />
         ) : (
           <IconPrint color="var(--accent-main)" />

--- a/src/features/congregation/field_service_groups/export_groups/index.tsx
+++ b/src/features/congregation/field_service_groups/export_groups/index.tsx
@@ -1,7 +1,8 @@
-import { IconLoading, IconPrint } from '@components/icons';
+import { IconPrint } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import useExportGroups from './useExportGroups';
 import Button from '@components/button';
+import WaitingLoader from '@components/waiting_loader';
 
 const ExportGroups = () => {
   const { t } = useAppTranslation();
@@ -13,8 +14,8 @@ const ExportGroups = () => {
       variant="secondary"
       onClick={handleExport}
       startIcon={
-        isProcessing ? (
-          <IconLoading color="var(--accent-main)" />
+        !isProcessing ? (
+          <WaitingLoader variant="standard" size={20} />
         ) : (
           <IconPrint color="var(--accent-main)" />
         )

--- a/src/features/congregation/settings/congregation_privacy/access_code_change/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/access_code_change/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { IconEncryptionKey, IconLoading } from '@components/icons';
+import { IconEncryptionKey } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { AccessCodeChangeType } from './index.types';
 import useAccessCodeChange from './useAccessCodeChange';
@@ -7,6 +7,7 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const AccessCodeChange = ({ open, onClose }: AccessCodeChangeType) => {
   const { t } = useAppTranslation();
@@ -79,7 +80,9 @@ const AccessCodeChange = ({ open, onClose }: AccessCodeChangeType) => {
         <Button
           variant="main"
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
           onClick={handleChangeAccessCode}
         >
           {t('tr_save')}

--- a/src/features/congregation/settings/congregation_privacy/delete_congregation/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/delete_congregation/index.tsx
@@ -1,11 +1,12 @@
 import { Box, Stack } from '@mui/material';
-import { IconDelete, IconEncryptionKey, IconLoading } from '@components/icons';
+import { IconDelete, IconEncryptionKey } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import useDeleteCongregation from './useDeleteCongregation';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const DeleteCongregation = () => {
   const { t } = useAppTranslation();
@@ -59,7 +60,15 @@ const DeleteCongregation = () => {
               variant="main"
               color="red"
               disabled={masterKey.length < 16}
-              endIcon={isProcessing && <IconLoading color="var(--white)" />}
+              endIcon={
+                isProcessing && (
+                  <WaitingLoader
+                    size={22}
+                    color="var(--white)"
+                    variant="standard"
+                  />
+                )
+              }
               onClick={handleDelete}
             >
               {t('tr_delete')}

--- a/src/features/congregation/settings/congregation_privacy/master_key_change/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/master_key_change/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { IconEncryptionKey, IconLoading } from '@components/icons';
+import { IconEncryptionKey } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { MasterKeyChangeType } from './index.types';
 import useMasterKeyChange from './useMasterKeyChange';
@@ -7,6 +7,7 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const MasterKeyChange = ({ open, onClose }: MasterKeyChangeType) => {
   const { t } = useAppTranslation();
@@ -79,7 +80,9 @@ const MasterKeyChange = ({ open, onClose }: MasterKeyChangeType) => {
         <Button
           variant="main"
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
           onClick={handleChangeMasterKey}
         >
           {t('tr_save')}

--- a/src/features/congregation/settings/import_export/confirm_import/index.tsx
+++ b/src/features/congregation/settings/import_export/confirm_import/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Grid2 as Grid, Stack } from '@mui/material';
-import { IconImportJson, IconLoading } from '@components/icons';
+import { IconImportJson } from '@components/icons';
 import { ConfirmImportProps } from './index.types';
 import { useAppTranslation, useBreakpoints } from '@hooks/index';
 import useConfirmImport from './useConfirmImport';
@@ -7,6 +7,7 @@ import Button from '@components/button';
 import Divider from '@components/divider';
 import Typography from '@components/typography';
 import Checkbox from '@components/checkbox';
+import WaitingLoader from '@components/waiting_loader';
 
 const ConfirmImport = (props: ConfirmImportProps) => {
   const { t } = useAppTranslation();
@@ -244,7 +245,9 @@ const ConfirmImport = (props: ConfirmImportProps) => {
         <Button
           variant="main"
           onClick={handleImportData}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
         >
           {t('tr_import')}
         </Button>

--- a/src/features/congregation/settings/import_export/export/index.tsx
+++ b/src/features/congregation/settings/import_export/export/index.tsx
@@ -1,10 +1,11 @@
 import { Box, Stack } from '@mui/material';
-import { IconBackupOrganized, IconLoading } from '@components/icons';
+import { IconBackupOrganized } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { ExportType } from './index.types';
 import useExport from './useExport';
 import Button from '@components/button';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const Export = (props: ExportType) => {
   const { t } = useAppTranslation();
@@ -31,7 +32,9 @@ const Export = (props: ExportType) => {
         <Button
           variant="main"
           onClick={handleDownload}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
         >
           {t('tr_download')}
         </Button>

--- a/src/features/congregation/settings/import_export/import/index.tsx
+++ b/src/features/congregation/settings/import_export/import/index.tsx
@@ -54,7 +54,7 @@ const Import = (props: ImportType) => {
         </Box>
       )}
 
-      {isProcessing && <WaitingLoader variant="standard" size={60} />}
+      {isProcessing && <WaitingLoader size={60} variant="standard" />}
 
       <Button variant="secondary" onClick={props.onClose}>
         {t('tr_cancel')}

--- a/src/features/contact/index.tsx
+++ b/src/features/contact/index.tsx
@@ -1,5 +1,5 @@
 import { Box, IconButton } from '@mui/material';
-import { IconClose, IconLoading, IconMail } from '@icons/index';
+import { IconClose, IconMail } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import useContact from './useContact';
 import Button from '@components/button';
@@ -7,6 +7,7 @@ import Dialog from '@components/dialog';
 import TextMarkup from '@components/text_markup';
 import Typography from '@components/typography';
 import TextField from '@components/textfield';
+import WaitingLoader from '@components/waiting_loader';
 
 const Contact = () => {
   const { t } = useAppTranslation();
@@ -87,7 +88,9 @@ const Contact = () => {
         <Button
           variant="main"
           onClick={handleSendMessage}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
         >
           {t('tr_sendFeedback')}
         </Button>

--- a/src/features/dashboard/initial_setup/person_record/index.tsx
+++ b/src/features/dashboard/initial_setup/person_record/index.tsx
@@ -5,7 +5,7 @@ import usePersonRecord from './usePersonRecord';
 import Button from '@components/button';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
-import { IconLoading } from '@components/icons';
+import WaitingLoader from '@components/waiting_loader';
 
 const PersonRecord = ({ onPrevious }: PersonRecordProps) => {
   const { t } = useAppTranslation();
@@ -54,7 +54,9 @@ const PersonRecord = ({ onPrevious }: PersonRecordProps) => {
         <Button
           variant="main"
           onClick={handleSavePerson}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
         >
           {t('tr_done')}
         </Button>

--- a/src/features/meeting_materials/epub_import/index.tsx
+++ b/src/features/meeting_materials/epub_import/index.tsx
@@ -1,7 +1,8 @@
 import SnackBar from '@components/snackbar';
-import { IconCheckCircle, IconLoading } from '@components/icons';
+import { IconCheckCircle } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import useEPUBMaterialsImport from './useEPUBMaterialsImport';
+import WaitingLoader from '@components/waiting_loader';
 
 const EPUBMaterialsImport = () => {
   const { t } = useAppTranslation();
@@ -22,7 +23,11 @@ const EPUBMaterialsImport = () => {
         isCompleted ? (
           <IconCheckCircle color="var(--always-white)" />
         ) : (
-          <IconLoading color="var(--always-white)" />
+          <WaitingLoader
+            size={24}
+            color="var(--always-white)"
+            variant="standard"
+          />
         )
       }
       variant={isCompleted ? 'success' : 'message-with-button'}

--- a/src/features/meeting_materials/jw_import/index.tsx
+++ b/src/features/meeting_materials/jw_import/index.tsx
@@ -1,7 +1,8 @@
 import SnackBar from '@components/snackbar';
 import useJWMaterialsImport from './useJWMaterialsImport';
 import { useAppTranslation } from '@hooks/index';
-import { IconCheckCircle, IconLoading } from '@components/icons';
+import { IconCheckCircle } from '@components/icons';
+import WaitingLoader from '@components/waiting_loader';
 
 const JWMaterialsImport = () => {
   const { t } = useAppTranslation();
@@ -22,7 +23,11 @@ const JWMaterialsImport = () => {
         isCompleted ? (
           <IconCheckCircle color="var(--always-white)" />
         ) : (
-          <IconLoading color="var(--always-white)" />
+          <WaitingLoader
+            size={24}
+            color="var(--always-white)"
+            variant="standard"
+          />
         )
       }
       variant={isCompleted ? 'success' : 'message-with-button'}

--- a/src/features/meetings/assignments_delete/index.tsx
+++ b/src/features/meetings/assignments_delete/index.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { AssignmentsDeleteType } from './index.types';
 import useAssignmentsDelete from './useAssignmentsDelete';
@@ -7,6 +6,7 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import Typography from '@components/typography';
 import WeekRangeSelector from '../week_range_selector';
+import WaitingLoader from '@components/waiting_loader';
 
 const AssignmentsDelete = ({
   open,
@@ -50,7 +50,9 @@ const AssignmentsDelete = ({
         <Button
           variant="main"
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
           onClick={handleClearAssignments}
         >
           {t('tr_clearSelectedWeeks')}

--- a/src/features/meetings/assignments_week_delete/index.tsx
+++ b/src/features/meetings/assignments_week_delete/index.tsx
@@ -1,11 +1,11 @@
 import { Box } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { AssignmentsWeekDeleteType } from './index.types';
 import { useAppTranslation } from '@hooks/index';
 import useAssignmentsDelete from './useAssignmentsWeekDelete';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const AssignmentsWeekDelete = ({
   open,
@@ -46,7 +46,9 @@ const AssignmentsWeekDelete = ({
           variant="main"
           color="red"
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
           onClick={handleClearAssignments}
         >
           {t('tr_clear')}

--- a/src/features/meetings/midweek_export/index.tsx
+++ b/src/features/meetings/midweek_export/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Stack } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { MidweekExportType } from './index.types';
 import useMidweekExport from './useMidweekExport';
@@ -11,6 +10,7 @@ import Typography from '@components/typography';
 import S89TemplateSelector from './S89TemplateSelector';
 import S140TemplateSelector from './S140TemplateSelector';
 import ScheduleRangeSelector from '../schedule_range_selector';
+import WaitingLoader from '@components/waiting_loader';
 
 const MidweekExport = ({ open, onClose }: MidweekExportType) => {
   const { t } = useAppTranslation();
@@ -110,7 +110,9 @@ const MidweekExport = ({ open, onClose }: MidweekExportType) => {
         <Button
           variant="main"
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
           onClick={handleExportSchedule}
         >
           {t('tr_export')}

--- a/src/features/meetings/outgoing_talks/schedule_delete/index.tsx
+++ b/src/features/meetings/outgoing_talks/schedule_delete/index.tsx
@@ -1,11 +1,11 @@
 import { Box } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { ScheduleDeleteType } from './index.types';
 import useAssignmentsDelete from './useScheduleDelete';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const ScheduleDelete = (props: ScheduleDeleteType) => {
   const { t } = useAppTranslation();
@@ -33,7 +33,9 @@ const ScheduleDelete = (props: ScheduleDeleteType) => {
           variant="main"
           color="red"
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
           onClick={handleDeleteSchedule}
         >
           {t('tr_delete')}

--- a/src/features/meetings/schedule_autofill/index.tsx
+++ b/src/features/meetings/schedule_autofill/index.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { ScheduleAutofillType } from './index.types';
 import useScheduleAutofill from './useScheduleAutofill';
@@ -7,6 +6,7 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import Typography from '@components/typography';
 import WeekRangeSelector from '../week_range_selector';
+import WaitingLoader from '@components/waiting_loader';
 
 const ScheduleAutofillDialog = ({
   open,
@@ -48,7 +48,9 @@ const ScheduleAutofillDialog = ({
         <Button
           variant="main"
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
           onClick={handleStartAutoFill}
         >
           {t('tr_autofill')}

--- a/src/features/meetings/schedule_publish/index.tsx
+++ b/src/features/meetings/schedule_publish/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Stack } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { SchedulePublishProps } from './index.types';
 import useSchedulePublish from './useSchedulePublish';
@@ -8,6 +7,7 @@ import Dialog from '@components/dialog';
 import Divider from '@components/divider';
 import Typography from '@components/typography';
 import YearContainer from './year_container';
+import WaitingLoader from '@components/waiting_loader';
 
 const SchedulePublish = (props: SchedulePublishProps) => {
   const { t } = useAppTranslation();
@@ -57,7 +57,9 @@ const SchedulePublish = (props: SchedulePublishProps) => {
           variant="main"
           disabled={isProcessing}
           onClick={handlePublishSchedule}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
         >
           {t('tr_publish')}
         </Button>

--- a/src/features/meetings/weekend_export/index.tsx
+++ b/src/features/meetings/weekend_export/index.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { WeekendExportType } from './index.types';
 import useWeekendExport from './useWeekendExport';
@@ -7,6 +6,7 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import Typography from '@components/typography';
 import WeekRangeSelector from '../week_range_selector';
+import WaitingLoader from '@components/waiting_loader';
 
 const WeekendExport = ({ open, onClose }: WeekendExportType) => {
   const { t } = useAppTranslation();
@@ -63,7 +63,9 @@ const WeekendExport = ({ open, onClose }: WeekendExportType) => {
         <Button
           variant="main"
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
           onClick={handleExportSchedule}
         >
           {t('tr_export')}

--- a/src/features/ministry/ap_application/submit_application/index.tsx
+++ b/src/features/ministry/ap_application/submit_application/index.tsx
@@ -1,7 +1,8 @@
-import { IconLoading, IconSend } from '@components/icons';
+import { IconSend } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import useSubmitApplication from './useSubmitApplication';
 import Button from '@components/button';
+import WaitingLoader from '@components/waiting_loader';
 
 const SubmitApplication = () => {
   const { t } = useAppTranslation();
@@ -11,7 +12,13 @@ const SubmitApplication = () => {
   return (
     <Button
       variant="main"
-      startIcon={isProcessing ? <IconLoading /> : <IconSend />}
+      startIcon={
+        isProcessing ? (
+          <WaitingLoader size={22} variant="standard" />
+        ) : (
+          <IconSend />
+        )
+      }
       disabled={disabled}
       onClick={handleSubmit}
     >

--- a/src/features/ministry/application_form/sc_member/action_buttons/index.tsx
+++ b/src/features/ministry/application_form/sc_member/action_buttons/index.tsx
@@ -1,12 +1,9 @@
-import {
-  IconCancelCicle,
-  IconCheckCircle,
-  IconLoading,
-} from '@components/icons';
+import { IconCancelCicle, IconCheckCircle } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { ActionButton } from '../index.styles';
 import { ActionButtonsProps } from './index.types';
 import useActionButtons from './useActionButtons';
+import WaitingLoader from '@components/waiting_loader';
 
 const ActionButtons = (props: ActionButtonsProps) => {
   const { t } = useAppTranslation();
@@ -25,7 +22,7 @@ const ActionButtons = (props: ActionButtonsProps) => {
         color="red"
         startIcon={
           isRejectProcessing ? (
-            <IconLoading />
+            <WaitingLoader size={22} variant="standard" />
           ) : (
             <IconCancelCicle color="var(--always-white)" />
           )
@@ -38,7 +35,7 @@ const ActionButtons = (props: ActionButtonsProps) => {
         variant="main"
         startIcon={
           isApproveProcessing ? (
-            <IconLoading />
+            <WaitingLoader size={22} variant="standard" />
           ) : (
             <IconCheckCircle color="var(--always-white)" />
           )

--- a/src/features/ministry/report/form_S4/submit_report/index.tsx
+++ b/src/features/ministry/report/form_S4/submit_report/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack } from '@mui/material';
-import { IconClose, IconLoading } from '@components/icons';
+import { IconClose } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { SubmitReportProps } from './index.types';
 import useSubmitReport from './useSubmitReport';
@@ -7,6 +7,7 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import IconButton from '@components/icon_button';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const SubmitReport = (props: SubmitReportProps) => {
   const { t } = useAppTranslation();
@@ -53,7 +54,9 @@ const SubmitReport = (props: SubmitReportProps) => {
           variant="main"
           onClick={handleTransferAndSubmit}
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
         >
           {minutes_remains === 0 ? t('tr_yes') : t('tr_btnTransfer')}
         </Button>

--- a/src/features/ministry/report/form_S4/withdraw_report/index.tsx
+++ b/src/features/ministry/report/form_S4/withdraw_report/index.tsx
@@ -1,11 +1,11 @@
 import { Stack } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { WithdrawReportProps } from './index.types';
 import useWithdrawReport from './useWithdrawReport';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const WithdrawReport = (props: WithdrawReportProps) => {
   const { t } = useAppTranslation();
@@ -25,7 +25,9 @@ const WithdrawReport = (props: WithdrawReportProps) => {
           variant="main"
           onClick={handleWithdrawal}
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
         >
           {t('tr_yes')}
         </Button>

--- a/src/features/my_profile/security/delete_account/index.tsx
+++ b/src/features/my_profile/security/delete_account/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack } from '@mui/material';
-import { IconEncryptionKey, IconLoading } from '@components/icons';
+import { IconEncryptionKey } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { DeleteAccountProps } from './index.types';
 import useDeleteAccount from './useDeleteAccount';
@@ -36,7 +36,7 @@ const DeleteAccount = ({ open, onClose }: DeleteAccountProps) => {
         )}
       </Stack>
 
-      {isLoading && <WaitingLoader variant="standard" size={72} />}
+      {isLoading && <WaitingLoader size={72} variant="standard" />}
 
       {!isLoading && isDeleteCong && (
         <TextField
@@ -66,7 +66,15 @@ const DeleteAccount = ({ open, onClose }: DeleteAccountProps) => {
               color="red"
               onClick={handleDelete}
               disabled={isDeleteCong ? masterKey.length < 16 : false}
-              endIcon={isProcessing && <IconLoading color="var(--black)" />}
+              endIcon={
+                isProcessing && (
+                  <WaitingLoader
+                    size={22}
+                    color="var(--black)"
+                    variant="standard"
+                  />
+                )
+              }
             >
               {t('tr_delete')}
             </Button>

--- a/src/features/my_profile/security/mfaDisable/index.tsx
+++ b/src/features/my_profile/security/mfaDisable/index.tsx
@@ -1,10 +1,10 @@
 import { Box } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import useMFADisable from './useMFADisable';
+import WaitingLoader from '@components/waiting_loader';
 
 type MFADisableType = {
   open: boolean;
@@ -39,7 +39,11 @@ const MFADisable = ({ open, onClose }: MFADisableType) => {
           onClick={handleDisable2FA}
           endIcon={
             isProcessing ? (
-              <IconLoading width={22} height={22} color="var(--black)" />
+              <WaitingLoader
+                size={22}
+                color="var(--black)"
+                variant="standard"
+              />
             ) : null
           }
         >

--- a/src/features/my_profile/security/mfaEnable/index.tsx
+++ b/src/features/my_profile/security/mfaEnable/index.tsx
@@ -1,5 +1,5 @@
 import { Badge, Box, IconButton } from '@mui/material';
-import { IconCopy, IconLoading } from '@components/icons';
+import { IconCopy } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import useMFAEnable from './useMFAEnable';
 import Button from '@components/button';
@@ -8,6 +8,7 @@ import OTPInput from '@components/otp_input';
 import Tabs from '@components/tabs';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 type MFAEnableType = {
   open: boolean;
@@ -51,7 +52,11 @@ const MFAEnable = ({ open, onClose }: MFAEnableType) => {
               width: '100%',
             }}
           >
-            <IconLoading color="var(--accent-main)" width={84} height={84} />
+            <WaitingLoader
+              size={84}
+              color="var(--accent-main)"
+              variant="standard"
+            />
           </Box>
         )}
         {!isLoading && (
@@ -199,7 +204,11 @@ const MFAEnable = ({ open, onClose }: MFAEnableType) => {
               onClick={handleVerifyOTP}
               endIcon={
                 isProcessing ? (
-                  <IconLoading width={22} height={22} color="var(--black)" />
+                  <WaitingLoader
+                    size={22}
+                    color="var(--black)"
+                    variant="standard"
+                  />
                 ) : undefined
               }
             >

--- a/src/features/my_profile/sessions/session_item/index.tsx
+++ b/src/features/my_profile/sessions/session_item/index.tsx
@@ -1,15 +1,11 @@
 import { Box } from '@mui/material';
-import {
-  IconClose,
-  IconComputer,
-  IconLoading,
-  IconPhone,
-} from '@components/icons';
+import { IconClose, IconComputer, IconPhone } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { SessionItemType } from './index.types';
 import useSessionItem from './useSessionItem';
 import Button from '@components/button';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const SessionItem = (props: SessionItemType) => {
   const { t } = useAppTranslation();
@@ -71,7 +67,11 @@ const SessionItem = (props: SessionItemType) => {
         variant="secondary"
         color={isCurrent ? 'green' : 'red'}
         startIcon={
-          isCurrent ? null : isProcessing ? <IconLoading /> : <IconClose />
+          isCurrent ? null : isProcessing ? (
+            <WaitingLoader size={22} variant="standard" />
+          ) : (
+            <IconClose />
+          )
         }
         onClick={isCurrent ? null : handleTerminate}
       >

--- a/src/features/reports/publisher_records/export_S21/all_records/index.tsx
+++ b/src/features/reports/publisher_records/export_S21/all_records/index.tsx
@@ -1,5 +1,4 @@
 import { FormControlLabel, RadioGroup, Stack } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { AllRecordsProps } from './index.types';
 import { ExportType } from '../index.types';
@@ -7,6 +6,7 @@ import useAllRecords from './useAllRecords';
 import Button from '@components/button';
 import Radio from '@components/radio';
 import Typography from '@components/typography';
+import WaitingLoader from '@components/waiting_loader';
 
 const AllRecords = (props: AllRecordsProps) => {
   const { t } = useAppTranslation();
@@ -47,7 +47,9 @@ const AllRecords = (props: AllRecordsProps) => {
           variant="main"
           onClick={handleExport}
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
         >
           {type === 'all' ? t('tr_export') : t('tr_next')}
         </Button>

--- a/src/features/reports/publisher_records/export_S21/specific_records/active_publishers/index.tsx
+++ b/src/features/reports/publisher_records/export_S21/specific_records/active_publishers/index.tsx
@@ -1,11 +1,11 @@
 import { Stack } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { ActivePublishersProps } from './index.types';
 import useActivePublishers from './useActivePublishers';
 import Button from '@components/button';
 import SearchBar from '@components/search_bar';
 import RichTreeViewCheckboxes from '@components/rich_tree_view/checkboxes';
+import WaitingLoader from '@components/waiting_loader';
 
 const ActivePublishers = (props: ActivePublishersProps) => {
   const { t } = useAppTranslation();
@@ -48,7 +48,9 @@ const ActivePublishers = (props: ActivePublishersProps) => {
           variant="main"
           onClick={handleExport}
           disabled={isProcessing}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
         >
           {btnLabel}
         </Button>

--- a/src/features/reports/publisher_records/export_S21/specific_records/field_service_groups/index.tsx
+++ b/src/features/reports/publisher_records/export_S21/specific_records/field_service_groups/index.tsx
@@ -1,11 +1,11 @@
 import { Stack } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { FieldServiceGroupsProps } from './index.types';
 import useFieldServiceGroups from './useFieldServiceGroups';
 import Button from '@components/button';
 import RichTreeViewCheckboxes from '@components/rich_tree_view/checkboxes';
 import SearchBar from '@components/search_bar';
+import WaitingLoader from '@components/waiting_loader';
 
 const FieldServiceGroups = (props: FieldServiceGroupsProps) => {
   const { t } = useAppTranslation();
@@ -48,7 +48,9 @@ const FieldServiceGroups = (props: FieldServiceGroupsProps) => {
           variant="main"
           disabled={isProcessing}
           onClick={handleExport}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
         >
           {btnLabel}
         </Button>

--- a/src/features/reports/publisher_records/export_S21/specific_records/inactive_publishers/index.tsx
+++ b/src/features/reports/publisher_records/export_S21/specific_records/inactive_publishers/index.tsx
@@ -1,11 +1,11 @@
 import { Stack } from '@mui/material';
-import { IconLoading } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { InactivePublishersProps } from './index.types';
 import useActivePublishers from './useInactivePublishers';
 import Button from '@components/button';
 import SearchBar from '@components/search_bar';
 import RichTreeViewCheckboxes from '@components/rich_tree_view/checkboxes';
+import WaitingLoader from '@components/waiting_loader';
 
 const InactivePublishers = (props: InactivePublishersProps) => {
   const { t } = useAppTranslation();
@@ -54,7 +54,9 @@ const InactivePublishers = (props: InactivePublishersProps) => {
           variant="main"
           disabled={isProcessing}
           onClick={handleExport}
-          endIcon={isProcessing && <IconLoading />}
+          endIcon={
+            isProcessing && <WaitingLoader size={22} variant="standard" />
+          }
         >
           {btnLabel}
         </Button>

--- a/src/features/reports/publisher_records_details/export_S21/index.tsx
+++ b/src/features/reports/publisher_records_details/export_S21/index.tsx
@@ -1,7 +1,8 @@
-import { IconExport, IconLoading } from '@components/icons';
+import { IconExport } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import useExportS21 from './useExportS21';
 import Button from '@components/button';
+import WaitingLoader from '@components/waiting_loader';
 
 const ExportS21 = () => {
   const { t } = useAppTranslation();
@@ -12,7 +13,13 @@ const ExportS21 = () => {
     <Button
       onClick={handleExport}
       disabled={isProcessing}
-      startIcon={isProcessing ? <IconLoading /> : <IconExport />}
+      startIcon={
+        isProcessing ? (
+          <WaitingLoader size={22} variant="standard" />
+        ) : (
+          <IconExport />
+        )
+      }
     >
       {t('tr_exportS21')}
     </Button>


### PR DESCRIPTION
# Description

Replaced custom SVG loaders with MUI's CircularProgress to improve perceived loading speed. <i>Apologies for the large commit (50 files instead of the usual max 15), but this is just a straightforward loader swap across all necessary files.</i>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
