### PR TITLE
feat: Improve Assignment Visibility with Tabs and Count Indicator

### DIFF
--- a/src/RootWrap.tsx
+++ b/src/RootWrap.tsx
@@ -45,6 +45,17 @@ const theme = createTheme({
     },
   },
   breakpoints: {
+    keys: [
+      'mobile',
+      'mobile400',
+      'tablet',
+      'tablet500',
+      'tablet600',
+      'tablet688',
+      'laptop',
+      'desktop',
+      'desktopLarge',
+    ],
     values: {
       mobile: 0,
       mobile400: 400,

--- a/src/components/tab_label_with_badge/index.tsx
+++ b/src/components/tab_label_with_badge/index.tsx
@@ -19,7 +19,7 @@ const LabelBadge = ({
       alignItems: 'center',
       height: '24px',
       fontSize: '14px',
-      opacity: 1,
+      opacity: value === 0 ? 0 : 1,
       transition: 'opacity 0.2s',
     }}
   >

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, SyntheticEvent, useEffect, useState } from 'react';
 import { Tabs as MUITabs, Tab, Box } from '@mui/material';
 import { TabsPanelProps, CustomTabProps } from './index.types';
+import useBreakpoints from '@hooks/useBreakpoints';
 
 /**
  * A custom tab panel component.
@@ -11,7 +12,8 @@ export const CustomTabPanel = (props: TabsPanelProps) => {
   const { children, value, index, ...other } = props;
 
   return (
-    <div
+    <Box
+      sx={{ height: '100%' }}
       role="tabpanel"
       hidden={value !== index}
       id={`simple-tabpanel-${index}`}
@@ -19,7 +21,7 @@ export const CustomTabPanel = (props: TabsPanelProps) => {
       {...other}
     >
       {value === index && <Box sx={{ padding: '24px 0' }}>{children}</Box>}
-    </div>
+    </Box>
   );
 };
 
@@ -41,8 +43,9 @@ const a11yProps = (index: number) => {
  *
  * @param tabs An array of tabs with label and corresponding component.
  */
-const Tabs = ({ tabs, value, onChange }: CustomTabProps) => {
+const Tabs = ({ tabs, value, onChange, actionComponent }: CustomTabProps) => {
   const [valueOfActivePanel, setValueOfActivePanel] = useState(value || 0);
+  const { tabletDown } = useBreakpoints();
 
   /**
    * Handle tab change event.
@@ -63,7 +66,15 @@ const Tabs = ({ tabs, value, onChange }: CustomTabProps) => {
 
   return (
     <Box sx={{ width: '100%' }}>
-      <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: tabletDown ? 'stretch' : 'center',
+          flexDirection: tabletDown ? 'column' : 'row',
+          rowGap: tabletDown ? '16px' : '0px',
+        }}
+      >
         <MUITabs
           value={valueOfActivePanel}
           onChange={handleChange}
@@ -94,6 +105,7 @@ const Tabs = ({ tabs, value, onChange }: CustomTabProps) => {
             )
           )}
         </MUITabs>
+        {actionComponent}
       </Box>
 
       {tabs.map(

--- a/src/components/tabs/index.types.ts
+++ b/src/components/tabs/index.types.ts
@@ -89,6 +89,11 @@ export interface CustomTabProps extends TabOwnProps {
   tabsCountOnScreen?: number;
 
   /**
+   * The action component to be displayed with the tab.
+   */
+  actionComponent?: ReactNode;
+
+  /**
    * Custom styling applied to the tab component using MUI's `sx` prop.
    */
   sx?: SxProps<Theme>;

--- a/src/features/meetings/my_assignments/index.tsx
+++ b/src/features/meetings/my_assignments/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack } from '@mui/material';
-import { useAppTranslation } from '@hooks/index';
+import { useAppTranslation, useBreakpoints } from '@hooks/index';
 import { IconInfo } from '@components/icons';
 import { DisplayRange } from './indextypes';
 import useMyAssignments from './useAssignments';
@@ -10,6 +10,8 @@ import MonthContainer from './month_container';
 import Select from '@components/select';
 import Typography from '@components/typography';
 import NoAssigmentsImg from '@assets/img/illustration_no_assigments.svg?component';
+import Tabs from '@components/tabs';
+import TabLabel from '@components/tab_label_with_badge';
 
 const MyAssignments = () => {
   const { t } = useAppTranslation();
@@ -21,8 +23,92 @@ const MyAssignments = () => {
     isSetup,
     displayRange,
     handleRangeChange,
-    personAssignments,
+    personAssignments: { ownAssignments, delegateAssignments },
   } = useMyAssignments();
+
+  const { tabletDown } = useBreakpoints();
+
+  const actionComponent = (
+    <Box
+      sx={{
+        width: tabletDown ? '100%' : '240px',
+      }}
+    >
+      <Select
+        label={t('tr_display')}
+        value={displayRange}
+        onChange={(e) => {
+          handleRangeChange(+e.target.value);
+        }}
+      >
+        <MenuItem value={DisplayRange.MONTHS_3}>
+          <Typography>{t('tr_next3MonthsLabel')}</Typography>
+        </MenuItem>
+        <MenuItem value={DisplayRange.MONTHS_6}>
+          <Typography>{t('tr_next6MonthsLabel')}</Typography>
+        </MenuItem>
+        <MenuItem value={DisplayRange.MONTHS_12}>
+          <Typography>{t('tr_next12MonthsLabel')}</Typography>
+        </MenuItem>
+      </Select>
+    </Box>
+  );
+
+  const renderAssignments = (assignments) => (
+    <Box
+      sx={{
+        height: '70vh',
+        overflowY: 'scroll',
+        '&::-webkit-scrollbar': {
+          width: '4px',
+        },
+      }}
+    >
+      {assignments.length === 0 ? (
+        <Box
+          sx={{
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '24px',
+          }}
+        >
+          <NoAssigmentsImg viewBox="0 0 128 128" />
+          <Stack spacing="8px">
+            <Typography className="h2">{t('tr_noAssignmentsYet')}</Typography>
+            <Typography
+              color="var(--grey-400)"
+              sx={{
+                maxWidth: '350px',
+              }}
+            >
+              {t('tr_noAssignmentsYetDesc')}
+            </Typography>
+          </Stack>
+        </Box>
+      ) : (
+        <Stack spacing={2.3}>
+          {assignments.map((month) => (
+            <MonthContainer key={month.month} monthData={month} />
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+
+  const tabs = [
+    {
+      label: <TabLabel count={ownAssignments.total} label={t('tr_myOwn')} />,
+      Component: renderAssignments(ownAssignments.byDate),
+    },
+    {
+      label: (
+        <TabLabel count={delegateAssignments.total} label={t('tr_delegated')} />
+      ),
+      Component: renderAssignments(delegateAssignments.byDate),
+    },
+  ];
 
   return (
     <Drawer
@@ -44,67 +130,17 @@ const MyAssignments = () => {
       )}
 
       {!isSetup && (
-        <>
-          <Select
-            label={t('tr_display')}
-            value={displayRange}
-            onChange={(e) => handleRangeChange(+e.target.value)}
-          >
-            <MenuItem value={DisplayRange.MONTHS_3}>
-              <Typography>{t('tr_next3MonthsLabel')}</Typography>
-            </MenuItem>
-            <MenuItem value={DisplayRange.MONTHS_6}>
-              <Typography>{t('tr_next6MonthsLabel')}</Typography>
-            </MenuItem>
-            <MenuItem value={DisplayRange.MONTHS_12}>
-              <Typography>{t('tr_next12MonthsLabel')}</Typography>
-            </MenuItem>
-          </Select>
-
-          <Box
-            sx={{
-              marginTop: '16px',
-              height: '100%',
-              overflow: 'auto',
-              '&::-webkit-scrollbar': {
-                width: '4px',
-              },
-            }}
-          >
-            {personAssignments.length === 0 && (
-              <Box
-                sx={{
-                  height: '100%',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: '24px',
-                }}
-              >
-                <NoAssigmentsImg viewBox="0 0 128 128" />
-                <Stack spacing="8px">
-                  <Typography className="h2">
-                    {t('tr_noAssignmentsYet')}
-                  </Typography>
-                  <Typography
-                    color="var(--grey-400)"
-                    sx={{
-                      maxWidth: '350px',
-                    }}
-                  >
-                    {t('tr_noAssignmentsYetDesc')}
-                  </Typography>
-                </Stack>
-              </Box>
-            )}
-
-            <Stack spacing={2.3}>
-              {personAssignments.map((month) => (
-                <MonthContainer key={month.month} monthData={month} />
-              ))}
-            </Stack>
-          </Box>
-        </>
+        <Box
+          sx={{
+            display: 'flex',
+            gap: '16px',
+            flexWrap: 'wrap',
+            justifyContent: 'space-between',
+            flexDirection: tabletDown ? 'column' : 'row',
+          }}
+        >
+          <Tabs tabs={tabs} actionComponent={actionComponent} />
+        </Box>
       )}
     </Drawer>
   );

--- a/src/features/persons/filter/index.tsx
+++ b/src/features/persons/filter/index.tsx
@@ -6,42 +6,7 @@ import { useAppTranslation, useBreakpoints } from '@hooks/index';
 import useFilter from './useFilter';
 import AssignmentGroup from '../assignment_group';
 import Tabs from '@components/tabs';
-
-const TabLabel = ({ label, count }: { label: string; count: number }) => {
-  return (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '8px',
-        transform: count === 0 && 'translateX(12px)',
-        transition: 'transform 0.2s',
-      }}
-    >
-      {label}
-      <LabelBadge value={count} />
-    </Box>
-  );
-};
-
-const LabelBadge = ({ value }: { value: number }) => (
-  <Box
-    sx={{
-      backgroundColor: 'var(--accent-150)',
-      borderRadius: 'var(--radius-s)',
-      width: '24px',
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      height: '24px',
-      fontSize: '14px',
-      opacity: value === 0 ? 0 : 1,
-      transition: 'opacity 0.2s',
-    }}
-  >
-    {value.toString()}
-  </Box>
-);
+import TabLabel from '@components/tab_label_with_badge';
 
 const PersonsFilter = () => {
   const { t } = useAppTranslation();

--- a/src/locales/en/congregation.json
+++ b/src/locales/en/congregation.json
@@ -87,6 +87,8 @@
   "tr_delegatePersons": "Delegate persons",
   "tr_delegatePersonsDesc": "By delegating a person from the congregation, you enable this user to view their meeting assignments and submit their field service reports.",
   "tr_delegatedPersons": "Delegated persons",
+  "tr_delegated": "Delegated",
+  "tr_myOwn": "My own",
   "tr_invitationCodeInstruction": "To add a new user’s device, generate the invitation code, and ask them to open <a href='https://organized-app.com' style='color: var(--accent-dark)'>organized-app.com</a>. Next, they should select their user type and enter the invitation code when prompted.",
   "tr_generateInvitationCode": "Generate invitation code",
   "tr_terminateSessionAdminDesc": "The user will stay logged in on their device until you terminate the session. After doing so, the user will need to log in to Organized again using their invitation code. Use this feature when absolutely necessary and in selective security-related cases.",


### PR DESCRIPTION
# Description

This PR introduces an improved way to separate "my own" assignments from those delegated to other publishers.

Additionally, to help prevent missing delegated assignments, a count indicator has been added to the tab. This works similarly to existing implementations (e.g., Persons → Filter, Publisher records page), showing the number of active assignments. The indicator will display either 0 or the total count of active assignments, providing an immediate overview without needing to open the tab.

Fixes # [(issue)](https://app.clickup.com/t/86c1tbbpc)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
