### PR TITLE
fix(components): fix size of update button for long words

### DIFF
--- a/src/components/info-message/index.tsx
+++ b/src/components/info-message/index.tsx
@@ -87,7 +87,11 @@ const InfoMessage = (props: InfoMessagePropsType) => {
           justifyContent: 'space-between',
         }}
       >
-        <Box>
+        <Box
+          sx={{
+            width: laptopDown ? '100%' : 'auto',
+          }}
+        >
           <Box
             sx={{
               display: 'flex',

--- a/src/components/info-message/index.tsx
+++ b/src/components/info-message/index.tsx
@@ -12,13 +12,13 @@ import { useBreakpoints } from '@hooks/index';
  * @returns JSX element for the CustomInfoMessage component.
  */
 const InfoMessage = (props: InfoMessagePropsType) => {
-  const { tablet500Down, mobile400Down } = useBreakpoints();
+  const { tablet500Down, mobile400Down, laptopDown } = useBreakpoints();
 
   const messageHeader = props.messageHeader || '';
   const message = props.message || '';
   const variant = props.variant || 'message-with-button';
 
-  const isActionTextLong = props.actionText?.length > 7;
+  const isActionTextLong = props.actionText?.length > 7 && laptopDown;
 
   /**
    * Function to get the background color based on the variant.
@@ -59,7 +59,7 @@ const InfoMessage = (props: InfoMessagePropsType) => {
           fill: 'var(--always-white)',
         },
         width: '100%',
-        maxWidth: { mobile: '100%', laptop: '544px' },
+        maxWidth: { mobile: '100%', laptop: '600px' },
         minHeight: '78px',
         background: getBackground(),
         padding: isActionTextLong
@@ -75,7 +75,7 @@ const InfoMessage = (props: InfoMessagePropsType) => {
       {!tablet500Down && props.messageIcon}
       <Box
         sx={{
-          minWidth: !mobile400Down ? '280px' : 'none',
+          minWidth: !mobile400Down ? '280px' : '230px',
           width: '100%',
           display: 'flex',
           flexDirection: isActionTextLong && 'column',


### PR DESCRIPTION
# Description
This fix changes the refresh button display technology a little, now the words will be carried over to the next line instead of being in one place.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
