### PR TITLE
feat(my_assignments): hide tabs when no persons delegated

### DIFF
--- a/src/components/drawer/index.tsx
+++ b/src/components/drawer/index.tsx
@@ -86,7 +86,7 @@ const Drawer: FC<DrawerProps & CustomDrawerProps> = ({
           direction={'row'}
           justifyContent={'space-between'}
           alignItems={'center'}
-          mb={'24px'}
+          mb={'12px'}
           ml={'12px'}
         >
           <Typography className="h1">{title}</Typography>

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -43,7 +43,13 @@ const a11yProps = (index: number) => {
  *
  * @param tabs An array of tabs with label and corresponding component.
  */
-const Tabs = ({ tabs, value, onChange, actionComponent }: CustomTabProps) => {
+const Tabs = ({
+  tabs,
+  value,
+  onChange,
+  actionComponent,
+  showTabs = true,
+}: CustomTabProps) => {
   const [valueOfActivePanel, setValueOfActivePanel] = useState(value || 0);
   const { tabletDown } = useBreakpoints();
 
@@ -75,36 +81,38 @@ const Tabs = ({ tabs, value, onChange, actionComponent }: CustomTabProps) => {
           rowGap: tabletDown ? '16px' : '0px',
         }}
       >
-        <MUITabs
-          value={valueOfActivePanel}
-          onChange={handleChange}
-          TabIndicatorProps={{
-            sx: {
-              backgroundColor: 'var(--accent-main)',
-              height: '4px',
-              borderRadius: '16px 16px 0 0',
-            },
-          }}
-          sx={{
-            '& button.Mui-selected': { color: 'var(--accent-main)' },
-            '& button:not(.Mui-selected)': { color: 'var(--grey-350)' },
-            // Programatically changing color of ripple (wave) when click happens:
-            '& span.MuiTouchRipple-rippleVisible': {
-              color: 'var(--accent-main)',
-            },
-          }}
-        >
-          {tabs.map(
-            ({ label, className }, index): ReactNode => (
-              <Tab
-                label={label}
-                key={index}
-                className={`${valueOfActivePanel === index ? 'h4' : 'body-regular'} ${className}`}
-                {...a11yProps(index)}
-              />
-            )
-          )}
-        </MUITabs>
+        {showTabs && (
+          <MUITabs
+            value={valueOfActivePanel}
+            onChange={handleChange}
+            TabIndicatorProps={{
+              sx: {
+                backgroundColor: 'var(--accent-main)',
+                height: '4px',
+                borderRadius: '16px 16px 0 0',
+              },
+            }}
+            sx={{
+              '& button.Mui-selected': { color: 'var(--accent-main)' },
+              '& button:not(.Mui-selected)': { color: 'var(--grey-350)' },
+              // Programatically changing color of ripple (wave) when click happens:
+              '& span.MuiTouchRipple-rippleVisible': {
+                color: 'var(--accent-main)',
+              },
+            }}
+          >
+            {tabs.map(
+              ({ label, className }, index): ReactNode => (
+                <Tab
+                  label={label}
+                  key={index}
+                  className={`${valueOfActivePanel === index ? 'h4' : 'body-regular'} ${className}`}
+                  {...a11yProps(index)}
+                />
+              )
+            )}
+          </MUITabs>
+        )}
         {actionComponent}
       </Box>
 

--- a/src/components/tabs/index.types.ts
+++ b/src/components/tabs/index.types.ts
@@ -94,6 +94,11 @@ export interface CustomTabProps extends TabOwnProps {
   actionComponent?: ReactNode;
 
   /**
+   * A boolean indicating whether to display the tabs. (Default: true)
+   */
+  showTabs?: boolean;
+
+  /**
    * Custom styling applied to the tab component using MUI's `sx` prop.
    */
   sx?: SxProps<Theme>;

--- a/src/features/meetings/my_assignments/index.tsx
+++ b/src/features/meetings/my_assignments/index.tsx
@@ -28,11 +28,12 @@ const MyAssignments = () => {
   } = useMyAssignments();
 
   const { tabletDown } = useBreakpoints();
+  const hasDelegatedAssignments = delegateAssignments.total > 0;
 
   const actionComponent = (
     <Box
       sx={{
-        width: tabletDown ? '100%' : '240px',
+        width: tabletDown || !hasDelegatedAssignments ? '100%' : '240px',
       }}
     >
       <Select
@@ -108,12 +109,19 @@ const MyAssignments = () => {
       label: <TabLabel count={ownAssignments.total} label={t('tr_myOwn')} />,
       Component: renderAssignments(ownAssignments.byDate),
     },
-    {
-      label: (
-        <TabLabel count={delegateAssignments.total} label={t('tr_delegated')} />
-      ),
-      Component: renderAssignments(delegateAssignments.byDate),
-    },
+    ...(hasDelegatedAssignments
+      ? [
+          {
+            label: (
+              <TabLabel
+                count={delegateAssignments.total}
+                label={t('tr_delegated')}
+              />
+            ),
+            Component: renderAssignments(delegateAssignments.byDate),
+          },
+        ]
+      : []),
   ];
 
   return (
@@ -145,7 +153,11 @@ const MyAssignments = () => {
             flexDirection: tabletDown ? 'column' : 'row',
           }}
         >
-          <Tabs tabs={tabs} actionComponent={actionComponent} />
+          <Tabs
+            tabs={tabs}
+            actionComponent={actionComponent}
+            showTabs={hasDelegatedAssignments}
+          />
         </Box>
       )}
     </Drawer>


### PR DESCRIPTION
# Description

- Hide the tabs for users that has NO persons delegated to them.
- Reduce the margin-bottom of the whole "My assignments" div from 24px to 12px.

Ref: https://app.clickup.com/t/86c2mjbf7

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
