### PR TITLE
Time picker focus and clock widget arrow color fixes

### DIFF
--- a/src/components/time_picker/index.tsx
+++ b/src/components/time_picker/index.tsx
@@ -155,6 +155,19 @@ const TimePicker = ({
                   top: 0,
                   right: 0,
                 },
+                '.MuiPickersArrowSwitcher-button': {
+                  color: 'var(--accent-150)',
+                },
+                '.MuiPickersArrowSwitcher-button:hover': {
+                  backgroundColor: 'var(--accent-150)',
+                  color: 'var(--accent-main)',
+                },
+                '.MuiIconButton-root': {
+                  color: 'var(--accent-350)',
+                },
+                '.Mui-disabled': {
+                  color: 'var(--accent-200)',
+                },
               },
             },
           }}

--- a/src/components/time_picker/slots/textfield.tsx
+++ b/src/components/time_picker/slots/textfield.tsx
@@ -59,7 +59,7 @@ const InputTextField = forwardRef(function DatePickerInputField(
             border: '1px solid var(--accent-main)',
           },
           '&.Mui-focused fieldset': {
-            border: '1px solid var(--accent-main)',
+            border: '1px solid var(--accent-main) !important',
           },
           '&.Mui-error': {
             '&:hover fieldset': {


### PR DESCRIPTION
# Description

Priority was added to ensure the correct color is displayed for the time picker field when focused, as previously the color did not match what was defined in the code. Additionally, code was added to customize the color of the arrows in the clock widget, and the arrow colors were also corrected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
