### PR TITLE
fix(components): swap the "Past dates" and "Upcoming dates" – Autofill selector field

### DIFF
--- a/src/features/meetings/week_range_selector/index.tsx
+++ b/src/features/meetings/week_range_selector/index.tsx
@@ -39,8 +39,8 @@ const WeekRangeSelector = ({
         defaultValue=""
         onChange={(e) => handleStartWeekChange(e.target.value as string)}
       >
-        <MenuSubHeader>{t('tr_pastDates')}</MenuSubHeader>
-        {startPastWeeks.map((option) => (
+        <MenuSubHeader>{t('tr_upcomingDates')}</MenuSubHeader>
+        {startUpcomingWeeks.map((option) => (
           <MenuItem key={option.value} value={option.value}>
             <Typography className="body-regular" color="var(--black)">
               {option.label}
@@ -48,8 +48,8 @@ const WeekRangeSelector = ({
           </MenuItem>
         ))}
 
-        <MenuSubHeader>{t('tr_upcomingDates')}</MenuSubHeader>
-        {startUpcomingWeeks.map((option) => (
+        <MenuSubHeader>{t('tr_pastDates')}</MenuSubHeader>
+        {startPastWeeks.map((option) => (
           <MenuItem key={option.value} value={option.value}>
             <Typography className="body-regular" color="var(--black)">
               {option.label}
@@ -69,8 +69,8 @@ const WeekRangeSelector = ({
           disabled={startWeek.length === 0}
           onChange={(e) => onEndChange?.(e.target.value as string)}
         >
-          <MenuSubHeader>{t('tr_pastDates')}</MenuSubHeader>
-          {endPastWeeks.map((option) => (
+          <MenuSubHeader>{t('tr_upcomingDates')}</MenuSubHeader>
+          {endUpcomingWeeks.map((option) => (
             <MenuItem key={option.value} value={option.value}>
               <Typography className="body-regular" color="var(--black)">
                 {option.label}
@@ -78,8 +78,8 @@ const WeekRangeSelector = ({
             </MenuItem>
           ))}
 
-          <MenuSubHeader>{t('tr_upcomingDates')}</MenuSubHeader>
-          {endUpcomingWeeks.map((option) => (
+          <MenuSubHeader>{t('tr_pastDates')}</MenuSubHeader>
+          {endPastWeeks.map((option) => (
             <MenuItem key={option.value} value={option.value}>
               <Typography className="body-regular" color="var(--black)">
                 {option.label}


### PR DESCRIPTION
# Description

Swapped the upcoming and past date lists so upcoming dates show first.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
