### PR TITLE
docs: fix misplaced frontend install step under Firebase environment setup

### DIFF
--- a/LOCAL_ENVIRONMENT_SETUP.md
+++ b/LOCAL_ENVIRONMENT_SETUP.md
@@ -95,7 +95,7 @@ _Before booting up the API server, let’s prepare our environment._
 2. With the terminal ready, let’s install the Firebase CLI using the command `npm i -g firebase-tools`. This command installs the Firebase CLI globally.
 3. Once installed, you might receive a notice from npm about a new minor version being available. If so, let’s install that quickly.
 4. To check if the Firebase CLI was installed correctly, use the command `firebase --version`. It should display the version of Firebase you just installed. For now, it’s 13.12.0.
-5. Now open the `organized-app` (frontend) repo and install the dependencies using the `npm i` command. This will start the installation of all the project’s dependencies.
+5. Now install the backend dependencies by running `npm i` inside the `sws2apps-api` folder. This will start the installation of all the project’s dependencies.
 
 #### Set up environment variables for the backend API
 


### PR DESCRIPTION
# Description

This PR corrects a small documentation issue in the “Prepare Firebase environment” section of the setup guide.
The original instructions asked users to install frontend dependencies (organized-app) during the backend setup process (sws2apps-api), which could lead to confusion and setup errors.

## Changes
I updated step 5 to correctly instruct users to install backend dependencies in the sws2apps-api repository before proceeding with Firebase emulator setup.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
