### PR TITLE
style(navbar): set the 'Open Real App' button top margin to 8px

### DIFF
--- a/src/layouts/navbar/index.tsx
+++ b/src/layouts/navbar/index.tsx
@@ -349,7 +349,7 @@ const NavBar = ({ isSupported }: NavBarType) => {
                       <Button
                         variant="tertiary"
                         startIcon={<IconArrowLink />}
-                        sx={{ width: '100%' }}
+                        sx={{ width: '100%', marginTop: '8px' }}
                       >
                         {t('tr_openRealApp')}
                       </Button>


### PR DESCRIPTION
# Description
This PR sets the `marginTop` of the **Open Real App** button in the navbar to `8px` for better vertical balance.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings