### PR TITLE
feat(bottom_menu): add gradient and truncation to mobile bottom menu

### DIFF
--- a/src/components/nav_bar_button/index.tsx
+++ b/src/components/nav_bar_button/index.tsx
@@ -32,7 +32,17 @@ const NavBarButton = (props: NavBarButtonProps) => {
       startIcon={props.icon}
       disabled={disabled}
     >
-      {props.text}
+      <Box
+        component="span"
+        sx={{
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          maxWidth: '100%',
+        }}
+      >
+        {props.text}
+      </Box>
     </Button>
   ) : (
     !disabled && (

--- a/src/layouts/bottom_menu/index.tsx
+++ b/src/layouts/bottom_menu/index.tsx
@@ -5,30 +5,46 @@ import { useAppTranslation } from '@hooks/index';
 const BottomMenu = (props: BottomMenuProps) => {
   const { t } = useAppTranslation();
   return (
-    <Box
-      component={'nav'}
-      aria-label={t('tr_bottomActionsMenu')}
-      sx={{
-        position: 'fixed',
-        backgroundColor: 'var(--accent-150)',
-        border: '1px solid var(--accent-200)',
-        borderRadius: 'var(--radius-xl)',
-        overflow: 'hidden',
-        bottom: '16px',
-        width: 'fit-content',
-        left: '50%',
-        transform: 'translate(-50%)',
-        zIndex: (theme) => theme.zIndex.drawer + 1,
-        boxShadow: 'var(--message-glow)',
-        padding: '6px',
-        display: 'flex',
-        flexDirection: 'row',
-        justifyContent: 'center',
-        gap: '4px',
-      }}
-    >
-      {props.buttons}
-    </Box>
+    <>
+      <Box
+        sx={{
+          position: 'fixed',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: '120px',
+          background:
+            'linear-gradient(180deg, rgba(var(--accent-100-base), 0) 0%, rgba(var(--accent-100-base), 0.85) 100%)',
+          zIndex: (theme) => theme.zIndex.drawer,
+          pointerEvents: 'none',
+        }}
+      />
+      <Box
+        component={'nav'}
+        aria-label={t('tr_bottomActionsMenu')}
+        sx={{
+          position: 'fixed',
+          backgroundColor: 'var(--accent-150)',
+          border: '1px solid var(--accent-200)',
+          borderRadius: 'var(--radius-xl)',
+          overflow: 'hidden',
+          bottom: '16px',
+          width: 'fit-content',
+          maxWidth: 'calc(100% - 32px)',
+          left: '50%',
+          transform: 'translate(-50%)',
+          zIndex: (theme) => theme.zIndex.drawer + 1,
+          boxShadow: 'var(--message-glow)',
+          padding: '6px',
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'center',
+          gap: '4px',
+        }}
+      >
+        {props.buttons}
+      </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
# Description

This PR enhances the mobile UX by improving the contrast of the bottom floating action buttons and handling long button localized labels better.

https://github.com/user-attachments/assets/8e3b0459-4c63-4853-aeac-8b7bd23fef49


Specifically, it:
1.  **Adds a Gradient Background**: A vertical linear gradient (`accent-100` fading from transparent to 85% opacity) is added behind the floating action button island on mobile devices. This improves visibility and separation from the content behind it.
2.  **Implements Text Truncation**: The NavBarButton component now supports text truncation with an ellipsis (`...`) for long labels, preventing them from wrapping to a second line and breaking the layout.
3.  **Adjusts Mobile Layout**: The BottomMenu container width is constrained to `calc(100% - 16px)` to ensure proper spacing and allow the truncation logic to function correctly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings