### PR TITLE
fix(public-talks): allow talk selection when speaker is manually entered

### DIFF
--- a/src/features/meetings/weekend_editor/public_talk_selector/usePublicTalkSelector.tsx
+++ b/src/features/meetings/weekend_editor/public_talk_selector/usePublicTalkSelector.tsx
@@ -74,7 +74,7 @@ const usePublicTalkSelector = (week: string, schedule_id?: string) => {
             (item) => item.talk_number === talk.talk_number
           );
 
-          if (speaker.length === 0 || talkFound) {
+          if (speaker.length === 0 || !visitingSpeaker || talkFound) {
             data.push({ ...talk, speakers: cnSpeakers.length });
           }
         }


### PR DESCRIPTION
# Description

This PR fixes a bug where manually typed visiting speakers (not selected from a list) were unable to select public talk themes. The issue occurred because the code only displayed talks when the speaker was found in the `incomingSpeakers` list OR when no speaker was selected, but not when a speaker was manually entered.

The root cause was in the `usePublicTalkSelector` hook, where the condition checked if `speaker.length === 0 || talkFound`, but didn't account for manually typed speakers who don't exist in the speakers list (`visitingSpeaker === undefined`).

**Solution:** Added an additional condition `|| !visitingSpeaker` to display all talks when a speaker is manually typed and not found in the predefined speakers list.

Fixes #4762

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
