### PR TITLE
fix(reports): correct pioneer monthly goal calculation

### DIFF
--- a/src/features/ministry/service_year/yearly_stats/pioneer_stats/usePioneerStats.tsx
+++ b/src/features/ministry/service_year/yearly_stats/pioneer_stats/usePioneerStats.tsx
@@ -195,10 +195,14 @@ const usePioneerStats = (year: string) => {
 
     if (months.length === 0) return '0:00';
 
-    const value = Math.round(minutes_left / months.length);
+    const pastRemainingMinutes = Math.max(
+      (goal - hours_fulltime.total) * 60,
+      0
+    );
+    const value = Math.round(pastRemainingMinutes / months.length);
 
     return convertMinutesToLongTime(value);
-  }, [end_month, reports, minutes_left, isCurrentSY]);
+  }, [end_month, reports, goal, hours_fulltime, isCurrentSY]);
 
   return {
     goal,


### PR DESCRIPTION
# Description

This PR fixes a bug in how the pioneer's "Current monthly goal" is calculated.

Previously, the goal was calculated using the remaining minutes which dynamically subtracted the active, unsubmitted hours of the *current* month. This caused the monthly target to constantly shrink as the user logged hours throughout the month, showing a wrong monthly goal:

![photo_2026-03-22 13 47 54](https://github.com/user-attachments/assets/98addc57-7427-46ca-aec6-5352040f5716)


**The Fix:**
The calculation has been updated to use the past remaining minutes instead. It now calculates the remaining deficit based *only* on fully submitted past months and divides that evenly by the remaining months. This provides a stable and mathematically correct monthly target.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
