### PR TITLE
fix(ui): adjust back arrow hover animation direction

### DIFF
--- a/src/layouts/navbar/index.tsx
+++ b/src/layouts/navbar/index.tsx
@@ -461,8 +461,8 @@ const NavBar = ({ isSupported }: NavBarType) => {
                         '& svg': {
                           transform:
                             theme.direction === 'rtl'
-                              ? 'translateX(4px) scaleX(-1)'
-                              : 'translateX(-4px)',
+                              ? 'translateX(-4px) scaleX(-1)'
+                              : 'translateX(4px)',
                         },
                       },
                       '& svg': {


### PR DESCRIPTION
# Description

Adjusted the hover animation direction of the back arrow icon in the MUI Toolbar. 

**Context:** Previously, the arrow slid slightly to the left on hover. This change ensures the arrow moves to the right, keeping it visually centered within its container during the hover state, as initially intended. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
