### PR TITLE
fix(pdf): resolve RTL layout issues for S-89 export

### DIFF
--- a/src/views/meetings/midweek/S89/4in1/index.tsx
+++ b/src/views/meetings/midweek/S89/4in1/index.tsx
@@ -12,11 +12,14 @@ import S89ToBeGiven from '../shared/S89ToBeGiven';
 import S89StudentNote from '../shared/S89StudentNote';
 import S89Footer from '../shared/S89Footer';
 import stylesCustom from './index.styles';
+import { applyRTL } from '@views/utils/pdf_utils';
 
 registerFonts();
 
 const TemplateS89Doc4in1 = ({ s89Data, lang }: S89Doc4in1Type) => {
   const { t } = useAppTranslation();
+  const rtlStyles = applyRTL(styles, lang);
+  const rtlStylesCustom = applyRTL(stylesCustom, lang);
 
   const formatData = () => {
     const data: S89DataType[][] = [];
@@ -31,37 +34,41 @@ const TemplateS89Doc4in1 = ({ s89Data, lang }: S89Doc4in1Type) => {
     <>
       {s89Data.length > 0 && (
         <Document title="S-89" lang={lang}>
-          <Page size="A4" style={[styles.body, stylesCustom.page]}>
+          <Page size="A4" style={[rtlStyles.body, rtlStylesCustom.page]}>
             {formatData().map((groupedData, groupedIndex) => {
               return (
                 <Fragment key={groupedData.map((d) => d.id).join('-')}>
                   {groupedData.map((data, index) => (
                     <View
                       key={data.id}
-                      style={{ ...styles.content, ...stylesCustom.content }}
+                      style={{ ...rtlStyles.content, ...rtlStylesCustom.content }}
                       break={groupedIndex > 0 && index === 0}
                     >
                       <View>
                         <S89Header lang={lang} />
 
-                        <View style={styles.details}>
+                        <View style={rtlStyles.details}>
                           <S89DetailsRow
+                            lang={lang}
                             field={`${t('tr_name', { lng: lang })}:`}
                             value={data.student_name}
                           />
 
                           <S89DetailsRow
+                            lang={lang}
                             field={`${t('tr_assistant', { lng: lang })}:`}
                             value={data.assistant_name}
                           />
 
                           <S89DetailsRow
+                            lang={lang}
                             field={`${t('tr_date', { lng: lang })}:`}
                             value={data.assignment_date}
                             align="center"
                           />
 
                           <S89DetailsRow
+                            lang={lang}
                             field={t('tr_partNo', { lng: lang })}
                             value={data.part_number}
                             align="center"
@@ -76,7 +83,7 @@ const TemplateS89Doc4in1 = ({ s89Data, lang }: S89Doc4in1Type) => {
                         />
                       </View>
 
-                      <View style={styles.bottomSection}>
+                      <View style={rtlStyles.bottomSection}>
                         <S89StudentNote lang={lang} />
                         <S89Footer lang={lang} />
                       </View>

--- a/src/views/meetings/midweek/S89/default/index.tsx
+++ b/src/views/meetings/midweek/S89/default/index.tsx
@@ -4,6 +4,7 @@ import { S89Type } from './index.types';
 import { useAppTranslation } from '@hooks/index';
 import registerFonts from '@views/registerFonts';
 import styles from '../shared/index.styles';
+import { applyRTL } from '@views/utils/pdf_utils';
 import S89Header from '../shared/S89Header';
 import S89DetailsRow from '../shared/S89DetailsRow';
 import S89ToBeGiven from '../shared/S89ToBeGiven';
@@ -14,31 +15,36 @@ registerFonts();
 
 const TemplateS89 = ({ data, lang }: S89Type) => {
   const { t } = useAppTranslation();
+  const rtlStyles = applyRTL(styles, lang);
 
   return (
     <Document title="S-89" lang={lang}>
-      <Page size={[241.2, 319.68]} style={styles.body}>
-        <View style={styles.content}>
+      <Page size={[241.2, 319.68]} style={rtlStyles.body}>
+        <View style={rtlStyles.content}>
           <View>
             <S89Header lang={lang} />
 
-            <View style={styles.details}>
+            <View style={rtlStyles.details}>
               <S89DetailsRow
+                lang={lang}
                 field={`${t('tr_name', { lng: lang })}:`}
                 value={data.student_name}
               />
 
               <S89DetailsRow
+                lang={lang}
                 field={`${t('tr_assistant', { lng: lang })}:`}
                 value={data.assistant_name}
               />
 
               <S89DetailsRow
+                lang={lang}
                 field={`${t('tr_date', { lng: lang })}:`}
                 value={data.assignment_date}
               />
 
               <S89DetailsRow
+                lang={lang}
                 field={t('tr_partNo', { lng: lang })}
                 value={data.part_number}
               />
@@ -52,7 +58,7 @@ const TemplateS89 = ({ data, lang }: S89Type) => {
             />
           </View>
 
-          <View style={styles.bottomSection}>
+          <View style={rtlStyles.bottomSection}>
             <S89StudentNote lang={lang} />
             <S89Footer lang={lang} />
           </View>

--- a/src/views/meetings/midweek/S89/shared/S89Class.tsx
+++ b/src/views/meetings/midweek/S89/shared/S89Class.tsx
@@ -2,15 +2,22 @@ import { Text, View } from '@react-pdf/renderer';
 import { S89ClassType } from './index.types';
 import styles from './index.styles';
 import Checkbox from '@views/components/checkbox';
+import { applyRTL, isRTL } from '@views/utils/pdf_utils';
 
 const CHECKBOX_SIZE = 13;
 
-const S89Class = ({ name = '', checked = false }: S89ClassType) => {
+const S89Class = ({ name = '', checked = false, lang }: S89ClassType & { lang: string }) => {
+  const rtlStyles = applyRTL(styles, lang);
+  const rtl = isRTL(lang);
+
   return (
-    <View style={styles.classItem}>
+    <View style={rtlStyles.classItem}>
       <Checkbox size={CHECKBOX_SIZE} checked={checked} />
 
-      <Text style={styles.classLabel}>{name}</Text>
+      <Text style={rtlStyles.classLabel}>
+        {rtl && '\u200f'}
+        {name}
+      </Text>
     </View>
   );
 };

--- a/src/views/meetings/midweek/S89/shared/S89Class.tsx
+++ b/src/views/meetings/midweek/S89/shared/S89Class.tsx
@@ -6,7 +6,7 @@ import { applyRTL, isRTL } from '@views/utils/pdf_utils';
 
 const CHECKBOX_SIZE = 13;
 
-const S89Class = ({ name = '', checked = false, lang }: S89ClassType & { lang: string }) => {
+const S89Class = ({ name = '', checked = false, lang }: S89ClassType) => {
   const rtlStyles = applyRTL(styles, lang);
   const rtl = isRTL(lang);
 

--- a/src/views/meetings/midweek/S89/shared/S89DetailsRow.tsx
+++ b/src/views/meetings/midweek/S89/shared/S89DetailsRow.tsx
@@ -1,17 +1,28 @@
 import { Text, View } from '@react-pdf/renderer';
 import { S89DetailsRowType } from './index.types';
 import styles from './index.styles';
+import { applyRTL, isRTL } from '@views/utils/pdf_utils';
 
 const S89DetailsRow = ({
   field = '',
   value = '',
   align = 'left',
-}: S89DetailsRowType) => {
+  lang,
+}: S89DetailsRowType & { lang: string }) => {
+  const rtlStyles = applyRTL(styles, lang);
+  const rtl = isRTL(lang);
+
   return (
-    <View style={styles.detailsRow}>
-      <Text style={styles.field}>{field}</Text>
-      <View style={{ ...styles.fieldValue, textAlign: align }}>
-        <Text style={styles.fieldValueText}>{value}</Text>
+    <View style={rtlStyles.detailsRow}>
+      <Text style={rtlStyles.field}>
+        {rtl && '\u200f'}
+        {field}
+      </Text>
+      <View style={{ ...rtlStyles.fieldValue, textAlign: rtl ? 'right' : align }}>
+        <Text style={rtlStyles.fieldValueText}>
+          {rtl && '\u200f'}
+          {value}
+        </Text>
       </View>
     </View>
   );

--- a/src/views/meetings/midweek/S89/shared/S89DetailsRow.tsx
+++ b/src/views/meetings/midweek/S89/shared/S89DetailsRow.tsx
@@ -23,6 +23,7 @@ const S89DetailsRow = ({
         <Text style={rtlStyles.fieldValueText}>
           {rtl && '\u200f'}
           {value}
+          {rtl && '\u200f'}
         </Text>
       </View>
     </View>

--- a/src/views/meetings/midweek/S89/shared/S89DetailsRow.tsx
+++ b/src/views/meetings/midweek/S89/shared/S89DetailsRow.tsx
@@ -17,6 +17,7 @@ const S89DetailsRow = ({
       <Text style={rtlStyles.field}>
         {rtl && '\u200f'}
         {field}
+        {rtl && '\u200f'}
       </Text>
       <View style={{ ...rtlStyles.fieldValue, textAlign: rtl ? 'right' : align }}>
         <Text style={rtlStyles.fieldValueText}>

--- a/src/views/meetings/midweek/S89/shared/S89Footer.tsx
+++ b/src/views/meetings/midweek/S89/shared/S89Footer.tsx
@@ -2,14 +2,17 @@ import { Text, View } from '@react-pdf/renderer';
 import { S89FooterType } from './index.types';
 import { LANGUAGE_LIST } from '@constants/index';
 import styles from './index.styles';
+import { applyRTL } from '@views/utils/pdf_utils';
 
 const S89Footer = ({ lang }: S89FooterType) => {
   const code =
     LANGUAGE_LIST.find((record) => record.threeLettersCode === lang)?.code ||
     'E';
 
+  const rtlStyles = applyRTL(styles, lang);
+
   return (
-    <View style={styles.footer}>
+    <View style={rtlStyles.footer}>
       <Text>S-89-{code.toUpperCase()}</Text>
       <Text>11/23</Text>
     </View>

--- a/src/views/meetings/midweek/S89/shared/S89Header.tsx
+++ b/src/views/meetings/midweek/S89/shared/S89Header.tsx
@@ -3,6 +3,7 @@ import { View } from '@react-pdf/renderer';
 import { useAppTranslation } from '@hooks/index';
 import { S89HeaderType } from './index.types';
 import styles from './index.styles';
+import { applyRTL, isRTL } from '@views/utils/pdf_utils';
 
 const S89Header = ({ lang }: S89HeaderType) => {
   const { t } = useAppTranslation();
@@ -10,13 +11,15 @@ const S89Header = ({ lang }: S89HeaderType) => {
   const largeLangs = ['ukr', 'mlg'];
 
   const isLargeHeader = largeLangs.includes(lang.toLowerCase());
+  const rtlStyles = applyRTL(styles, lang);
+  const rtl = isRTL(lang);
 
   return (
-    <View style={styles.header}>
+    <View style={rtlStyles.header}>
       <Html
-        style={{ fontSize: isLargeHeader ? '10px' : styles.header.fontSize }}
+        style={{ fontSize: isLargeHeader ? '10px' : rtlStyles.header.fontSize }}
       >
-        {t('tr_s89Title', { lng: lang })}
+        {`${rtl ? '\u200f' : ''}${t('tr_s89Title', { lng: lang })}`}
       </Html>
     </View>
   );

--- a/src/views/meetings/midweek/S89/shared/S89StudentNote.tsx
+++ b/src/views/meetings/midweek/S89/shared/S89StudentNote.tsx
@@ -2,17 +2,19 @@ import { Text as PdfText, View } from '@react-pdf/renderer';
 import { useAppTranslation } from '@hooks/index';
 import { S89StudentNoteProps } from './index.types';
 import styles from './index.styles';
+import { applyRTL, isRTL } from '@views/utils/pdf_utils';
 
 const RICH_TEXT_REGEX = /((?:<b>.*?<\/b>)|(?:<i>.*?<\/i>))/g;
 
 const S89StudentNote = ({ lang }: S89StudentNoteProps) => {
   const { t } = useAppTranslation();
-  const text = t('tr_s89DescFooter', { lng: lang });
+  const text = `${isRTL(lang) ? '\u200f' : ''}${t('tr_s89DescFooter', { lng: lang })}`;
 
   const parts = text.split(RICH_TEXT_REGEX).filter(Boolean);
+  const rtlStyles = applyRTL(styles, lang);
 
   return (
-    <View style={styles.studentNote}>
+    <View style={rtlStyles.studentNote}>
       <PdfText>
         {parts.map((part, index) => {
           let content = part;

--- a/src/views/meetings/midweek/S89/shared/S89ToBeGiven.tsx
+++ b/src/views/meetings/midweek/S89/shared/S89ToBeGiven.tsx
@@ -14,7 +14,9 @@ const S89ToBeGiven = ({ main_hall, aux_class_1, lang }: S89ToBeGivenType) => {
     <View style={rtlStyles.toBeGiven}>
       <Text>
         {rtl && '\u200f'}
-        {t('tr_s89ToBeGiven', { lng: lang })}{' '}
+        {t('tr_s89ToBeGiven', { lng: lang })}
+        {rtl && '\u200f'}
+        {' '}
       </Text>
       <View style={rtlStyles.classes}>
         <S89Class lang={lang} name={t('tr_mainHall', { lng: lang })} checked={main_hall} />

--- a/src/views/meetings/midweek/S89/shared/S89ToBeGiven.tsx
+++ b/src/views/meetings/midweek/S89/shared/S89ToBeGiven.tsx
@@ -3,20 +3,27 @@ import { useAppTranslation } from '@hooks/index';
 import S89Class from './S89Class';
 import styles from './index.styles';
 import { S89ToBeGivenType } from './index.types';
+import { applyRTL, isRTL } from '@views/utils/pdf_utils';
 
 const S89ToBeGiven = ({ main_hall, aux_class_1, lang }: S89ToBeGivenType) => {
   const { t } = useAppTranslation();
+  const rtlStyles = applyRTL(styles, lang);
+  const rtl = isRTL(lang);
 
   return (
-    <View style={styles.toBeGiven}>
-      <Text>{t('tr_s89ToBeGiven', { lng: lang })} </Text>
-      <View style={styles.classes}>
-        <S89Class name={t('tr_mainHall', { lng: lang })} checked={main_hall} />
+    <View style={rtlStyles.toBeGiven}>
+      <Text>
+        {rtl && '\u200f'}
+        {t('tr_s89ToBeGiven', { lng: lang })}{' '}
+      </Text>
+      <View style={rtlStyles.classes}>
+        <S89Class lang={lang} name={t('tr_mainHall', { lng: lang })} checked={main_hall} />
         <S89Class
+          lang={lang}
           name={t('tr_auxClass1', { lng: lang })}
           checked={aux_class_1}
         />
-        <S89Class name={t('tr_auxClass2', { lng: lang })} />
+        <S89Class lang={lang} name={t('tr_auxClass2', { lng: lang })} />
       </View>
     </View>
   );

--- a/src/views/meetings/midweek/S89/shared/index.styles.ts
+++ b/src/views/meetings/midweek/S89/shared/index.styles.ts
@@ -49,6 +49,7 @@ const styles = StyleSheet.create({
     marginTop: '16px',
     fontSize: '12px',
     fontWeight: 800,
+    textAlign: 'left',
   },
   classes: {
     marginTop: '2px',

--- a/src/views/meetings/midweek/S89/shared/index.types.ts
+++ b/src/views/meetings/midweek/S89/shared/index.types.ts
@@ -1,12 +1,14 @@
 export type S89ClassType = {
   name: string;
   checked?: boolean;
+  lang: string;
 };
 
 export type S89DetailsRowType = {
   field: string;
   value: string;
   align?: 'left' | 'center' | 'right' | 'justify';
+  lang: string;
 };
 
 export type S89ToBeGivenType = {


### PR DESCRIPTION
# Description

This PR resolves Right-to-Left layout issues when exporting the S-89 assignment form to PDF in languages such as Hebrew. It applies the same RTL utility patterns used in the S-140 templates to structurally mirror the S-89 PDF layouts (`default` and `4-in-1`). Additionally, it fixes neutral punctuation rendering (colons) in the `@react-pdf/renderer` BiDi algorithm by wrapping the target nodes with RTL marker characters (`\u200f`), and properly adjusts explicit text alignments where necessary.

Fixes #5119

<img width="685" height="895" alt="Screenshot 2026-04-06 at 03 19 03" src="https://github.com/user-attachments/assets/4dff9f2a-6dc9-4c67-8e82-5ce953c32191" />


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
