### PR TITLE
fix(ui): attendance grid mobile layout and input padding

### DIFF
--- a/src/features/reports/meeting_attendance/monthly_record/meeting_item/index.tsx
+++ b/src/features/reports/meeting_attendance/monthly_record/meeting_item/index.tsx
@@ -34,7 +34,20 @@ const MeetingItem = (props: MeetingItemProps) => {
         </Typography>
       </Box>
 
-      <Stack spacing="16px" direction={tablet600Up ? 'row' : 'column'}>
+      <Box
+        sx={{
+          display: 'grid',
+          gap: '16px',
+          gridTemplateColumns: tablet600Up
+            ? `repeat(${weeksCount.length}, 1fr)`
+            : 'repeat(2, 1fr)',
+          ...(!tablet600Up && {
+            '& > :last-child:nth-of-type(odd)': {
+              gridColumn: '1 / -1',
+            },
+          }),
+        }}
+      >
         {weeksCount.map((week) => (
           <WeekBox
             key={`present-${week.toString()}`}
@@ -43,7 +56,7 @@ const MeetingItem = (props: MeetingItemProps) => {
             type={type}
           />
         ))}
-      </Stack>
+      </Box>
 
       {groups.length > 0 && (
         <>
@@ -63,9 +76,19 @@ const MeetingItem = (props: MeetingItemProps) => {
                   </Typography>
                 </Box>
 
-                <Stack
-                  spacing="16px"
-                  direction={tablet600Up ? 'row' : 'column'}
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gap: '16px',
+                    gridTemplateColumns: tablet600Up
+                      ? `repeat(${weeksCount.length}, 1fr)`
+                      : 'repeat(2, 1fr)',
+                    ...(!tablet600Up && {
+                      '& > :last-child:nth-of-type(odd)': {
+                        gridColumn: '1 / -1',
+                      },
+                    }),
+                  }}
                 >
                   {weeksCount.map((week) => (
                     <WeekBox
@@ -76,7 +99,7 @@ const MeetingItem = (props: MeetingItemProps) => {
                       view={group.id}
                     />
                   ))}
-                </Stack>
+                </Box>
               </Stack>
             ))}
           </Stack>

--- a/src/features/reports/meeting_attendance/monthly_record/week_box/index.styles.ts
+++ b/src/features/reports/meeting_attendance/monthly_record/week_box/index.styles.ts
@@ -8,7 +8,7 @@ export const TextFieldStyles: SxProps<Theme> = {
     textAlign: 'center',
   },
   '& input': {
-    padding: '10.5px 2px',
+    padding: '10.5px 10px 10.5px 2px',
   },
   '& input::-webkit-outer-spin-button': {
     WebkitAppearance: 'none',


### PR DESCRIPTION
# Description

This PR improves the attendance record UI for mobile devices and adjusts input padding.

- Implements a 2-column grid for weeks on mobile (≥320px) to reduce vertical scrolling.
- Adds right padding to number inputs so native browser spinner buttons don't overlap the content.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings