### PR TITLE
fix(ui): add spacing to open real app button

### DIFF
--- a/src/layouts/navbar/index.tsx
+++ b/src/layouts/navbar/index.tsx
@@ -377,7 +377,7 @@ const NavBar = ({ isSupported }: NavBarType) => {
                             <Button
                               variant="tertiary"
                               startIcon={<IconArrowLink />}
-                              sx={{ width: '100%' }}
+                              sx={{ width: '100%', marginTop: '8px' }}
                             >
                               {t('tr_openRealApp')}
                             </Button>


### PR DESCRIPTION
Added an 8px top margin to the 'Open real app' button in the user menu to improve spacing.