### PR TITLE
feat(persons): Auxiliary classroom only qualification

### DIFF
--- a/src/components/assignments_checklist/index.tsx
+++ b/src/components/assignments_checklist/index.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
   useCallback,
   useEffect,
+  useMemo,
 } from 'react';
 import {
   StyledContentBox,
@@ -36,17 +37,36 @@ export const AssignmentCheckList = ({
 
   const { tablet600Down } = useBreakpoints();
 
-  const allChecked =
-    Object.values(checkedItems).length > 0 &&
-    Object.values(checkedItems).every((item) => item);
-  const someChecked = Object.values(checkedItems).some((item) => item);
+  const mainChildrenIndices = useMemo(() => {
+    const indices: number[] = [];
+    Children.forEach(children, (child, index) => {
+      if (isValidElement(child)) {
+        if (!child.props['disabled'] && !child.props['special']) {
+          indices.push(index);
+        }
+      }
+    });
+    return indices;
+  }, [children]);
+
+  const allChecked = useMemo(() => {
+    return (
+      mainChildrenIndices.length > 0 &&
+      mainChildrenIndices.every((index) => checkedItems[index])
+    );
+  }, [mainChildrenIndices, checkedItems]);
+
+  const someChecked = useMemo(() => {
+    return mainChildrenIndices.some((index) => checkedItems[index]);
+  }, [mainChildrenIndices, checkedItems]);
 
   const onMainCheckboxClick = useCallback(() => {
     const newCheckedState = allChecked ? !allChecked : !checkedMain;
-    const newCheckedItems = {};
+    const newCheckedItems = { ...checkedItems };
+
     Children.forEach(children, (child, index) => {
       if (isValidElement(child)) {
-        if (child.props['disabled']) return;
+        if (child.props['disabled'] || child.props['special']) return;
         newCheckedItems[index] = newCheckedState;
       }
     });
@@ -55,7 +75,7 @@ export const AssignmentCheckList = ({
     setCheckedMain(newCheckedState);
 
     onChange?.(newCheckedState);
-  }, [allChecked, checkedMain, children, onChange]);
+  }, [allChecked, checkedMain, children, onChange, checkedItems]);
 
   const onChildCheckboxClick = (index) => {
     setCheckedItems({ ...checkedItems, [index]: !checkedItems[index] });
@@ -91,13 +111,15 @@ export const AssignmentCheckList = ({
       }
     });
     setCheckedItems(defaultValues);
-    setCheckedMain(
-      Object.values(defaultValues).length > 0 &&
-        Object.values(defaultValues).every((item) => item)
-        ? true
-        : false
+
+    const mainItemsChecked = mainChildrenIndices.every(
+      (index) => defaultValues[index]
     );
-  }, [children]);
+
+    setCheckedMain(
+      mainChildrenIndices.length > 0 && mainItemsChecked ? true : false
+    );
+  }, [children, mainChildrenIndices]);
 
   const calculateWidthForStyledContentBox = (): string => {
     if (!disabled) {

--- a/src/components/assignments_checklist/index.tsx
+++ b/src/components/assignments_checklist/index.tsx
@@ -41,7 +41,7 @@ export const AssignmentCheckList = ({
     const indices: number[] = [];
     Children.forEach(children, (child, index) => {
       if (isValidElement(child)) {
-        if (!child.props['disabled'] && !child.props['special']) {
+        if (!child.props['disabled']) {
           indices.push(index);
         }
       }
@@ -66,8 +66,9 @@ export const AssignmentCheckList = ({
 
     Children.forEach(children, (child, index) => {
       if (isValidElement(child)) {
-        if (child.props['disabled'] || child.props['special']) return;
-        newCheckedItems[index] = newCheckedState;
+        if (mainChildrenIndices.includes(index)) {
+          newCheckedItems[index] = newCheckedState;
+        }
       }
     });
 
@@ -75,7 +76,7 @@ export const AssignmentCheckList = ({
     setCheckedMain(newCheckedState);
 
     onChange?.(newCheckedState);
-  }, [allChecked, checkedMain, children, onChange, checkedItems]);
+  }, [allChecked, checkedMain, children, onChange, checkedItems, mainChildrenIndices]);
 
   const onChildCheckboxClick = (index) => {
     setCheckedItems({ ...checkedItems, [index]: !checkedItems[index] });

--- a/src/components/checkbox/index.types.ts
+++ b/src/components/checkbox/index.types.ts
@@ -56,9 +56,4 @@ export type CheckboxPropsType = {
   readOnly?: boolean;
 
   stopPropagation?: boolean;
-
-  /**
-   * Whether the checkbox is special and should be ignored by bulk actions in parents.
-   */
-  special?: boolean;
 };

--- a/src/components/checkbox/index.types.ts
+++ b/src/components/checkbox/index.types.ts
@@ -56,4 +56,9 @@ export type CheckboxPropsType = {
   readOnly?: boolean;
 
   stopPropagation?: boolean;
+
+  /**
+   * Whether the checkbox is special and should be ignored by bulk actions in parents.
+   */
+  special?: boolean;
 };

--- a/src/definition/assignment.ts
+++ b/src/definition/assignment.ts
@@ -29,6 +29,7 @@ export enum AssignmentCode {
   MM_AuxiliaryCounselor = 128,
   MM_AssistantOnly = 129,
   WM_WTStudyConductor = 130,
+  MM_AuxiliaryClassroomOnly = 131,
   MINISTRY_HOURS_CREDIT = 300,
 }
 

--- a/src/features/congregation/settings/shared_styles/index.tsx
+++ b/src/features/congregation/settings/shared_styles/index.tsx
@@ -5,7 +5,7 @@ import Markup from '@components/text_markup';
 import Typography from '@components/typography';
 import Divider from '@components/divider';
 
-export const CardSection = styled(Box)({
+const CardSectionStyled = styled(Box)({
   backgroundColor: 'var(--white)',
   padding: '15px',
   border: '1px solid var(--accent-300)',
@@ -13,16 +13,24 @@ export const CardSection = styled(Box)({
   display: 'flex',
   flexDirection: 'column',
   gap: '24px',
-}) as unknown as typeof Box;
+});
 
-export const TwoColumnsRow = styled(Box)({
+export const CardSection = (props: PropsWithChildren & SxProps) => {
+  return <CardSectionStyled {...props} />;
+};
+
+const TwoColumnsRowStyled = styled(Box)({
   display: 'flex',
   gap: '16px',
   alignItems: 'center',
   '> *': {
     flex: '1 0 0',
   },
-}) as unknown as typeof Box;
+});
+
+export const TwoColumnsRow = (props: PropsWithChildren & SxProps) => {
+  return <TwoColumnsRowStyled {...props} />;
+};
 
 export const CardSectionTitle = ({ children }: PropsWithChildren) => {
   return <Typography className="h2">{children}</Typography>;

--- a/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
+++ b/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
@@ -109,8 +109,15 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
         record.person_data.assignments.find((a) => a.type === dataView)
           ?.values ?? [];
 
+      const isAuxClass = assignment.endsWith('_B') || assignment.endsWith('_C');
+      const isMainHall = !isAuxClass;
+
       if (!isAssistant) {
         return (
+          (!isMainHall ||
+            !activeAssignments.includes(
+              AssignmentCode.MM_AuxiliaryClassroomOnly
+            )) &&
           activeAssignments.includes(type) &&
           ((gender === 'male' && record.person_data.male.value) ||
             (gender === 'female' && record.person_data.female.value))
@@ -155,7 +162,14 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
 
           const isFamily = isFamilyMembers || isFamilyHead;
 
+          const isEligibleForClassroom =
+            !isMainHall ||
+            !activeAssignments.includes(
+              AssignmentCode.MM_AuxiliaryClassroomOnly
+            );
+
           return (
+            isEligibleForClassroom &&
             assignment &&
             (isFamily ||
               (record.person_data.male.value === isMale &&

--- a/src/features/persons/assignment_group/index.tsx
+++ b/src/features/persons/assignment_group/index.tsx
@@ -1,3 +1,4 @@
+import { AssignmentCode } from '@definition/assignment';
 import { AssignmentGroupType } from './index.types';
 import useAssignmentGroup from './useAssignmentGroup';
 import AssignmentsCheckList from '@components/assignments_checklist';
@@ -43,30 +44,39 @@ const AssignmentGroup = ({
         onChange={(checked) => onHeaderChange(checked, id)}
         readOnly={readOnly}
       >
-        {items.map((assignment) => (
-          <Checkbox
-            key={assignment.code}
-            readOnly={readOnly}
-            label={assignment.name}
-            checked={
-              checkAssignmentDisabled(assignment.code)
-                ? false
-                : checkedItems.includes(assignment.code)
-            }
-            onChange={(_, checked) => onItemChange(checked, assignment.code)}
-            className="body-small-regular"
-            disabled={disqualified || checkAssignmentDisabled(assignment.code)}
-            sx={
-              assignment.borderTop
-                ? {
-                    borderTop: '1px solid var(--accent-200)',
-                    marginTop: '4px',
-                    paddingTop: '8px',
-                  }
-                : {}
-            }
-          />
-        ))}
+        {items.map((assignment) => {
+          const isSpecial =
+            assignment.code === AssignmentCode.MM_AssistantOnly ||
+            assignment.code === AssignmentCode.MM_AuxiliaryClassroomOnly;
+
+          return (
+            <Checkbox
+              key={assignment.code}
+              readOnly={readOnly}
+              label={assignment.name}
+              special={isSpecial}
+              checked={
+                checkAssignmentDisabled(assignment.code)
+                  ? false
+                  : checkedItems.includes(assignment.code)
+              }
+              onChange={(_, checked) => onItemChange(checked, assignment.code)}
+              className="body-small-regular"
+              disabled={
+                disqualified || checkAssignmentDisabled(assignment.code)
+              }
+              sx={
+                assignment.borderTop
+                  ? {
+                      borderTop: '1px solid var(--accent-200)',
+                      marginTop: '4px',
+                      paddingTop: '8px',
+                    }
+                  : {}
+              }
+            />
+          );
+        })}
       </AssignmentsCheckList>
     </Tooltip>
   );

--- a/src/features/persons/assignment_group/index.tsx
+++ b/src/features/persons/assignment_group/index.tsx
@@ -1,4 +1,3 @@
-import { AssignmentCode } from '@definition/assignment';
 import { AssignmentGroupType } from './index.types';
 import useAssignmentGroup from './useAssignmentGroup';
 import AssignmentsCheckList from '@components/assignments_checklist';
@@ -45,16 +44,11 @@ const AssignmentGroup = ({
         readOnly={readOnly}
       >
         {items.map((assignment) => {
-          const isSpecial =
-            assignment.code === AssignmentCode.MM_AssistantOnly ||
-            assignment.code === AssignmentCode.MM_AuxiliaryClassroomOnly;
-
           return (
             <Checkbox
               key={assignment.code}
               readOnly={readOnly}
               label={assignment.name}
-              special={isSpecial}
               checked={
                 checkAssignmentDisabled(assignment.code)
                   ? false

--- a/src/features/persons/assignment_group/useAssignmentGroup.tsx
+++ b/src/features/persons/assignment_group/useAssignmentGroup.tsx
@@ -88,6 +88,7 @@ const useAssignmentGroup = (male: boolean) => {
       if (code === AssignmentCode.MM_MakingDisciples) isDisabled = false;
       if (code === AssignmentCode.MM_ExplainingBeliefs) isDisabled = false;
       if (code === AssignmentCode.MM_AssistantOnly) isDisabled = false;
+      if (code === AssignmentCode.MM_AuxiliaryClassroomOnly) isDisabled = false;
     }
     return isDisabled;
   };

--- a/src/features/persons/assignment_group/useAssignmentGroup.tsx
+++ b/src/features/persons/assignment_group/useAssignmentGroup.tsx
@@ -55,13 +55,16 @@ const useAssignmentGroup = (male: boolean) => {
       return !isPioneer;
     }
 
-    if (code === AssignmentCode.MM_AssistantOnly) {
+    if (
+      code === AssignmentCode.MM_AssistantOnly ||
+      code === AssignmentCode.MM_AuxiliaryClassroomOnly
+    ) {
       if (
         assignments.some(
           (record) =>
             (record >= AssignmentCode.MM_StartingConversation &&
               record <= AssignmentCode.MM_Discussion) ||
-            record == AssignmentCode.MM_Talk
+            record === AssignmentCode.MM_Talk
         )
       ) {
         return true;
@@ -74,7 +77,11 @@ const useAssignmentGroup = (male: boolean) => {
       code === AssignmentCode.MM_Talk
     ) {
       if (
-        assignments.some((record) => record === AssignmentCode.MM_AssistantOnly)
+        assignments.some(
+          (record) =>
+            record === AssignmentCode.MM_AssistantOnly ||
+            record === AssignmentCode.MM_AuxiliaryClassroomOnly
+        )
       ) {
         return true;
       }

--- a/src/features/persons/assignments/assignmentStructure.ts
+++ b/src/features/persons/assignments/assignmentStructure.ts
@@ -58,6 +58,10 @@ export const ASSIGNMENT_SECTIONS: AssignmentSection[] = [
         nameKey: 'tr_assistantOnly',
         borderTop: true,
       },
+      {
+        code: AssignmentCode.MM_AuxiliaryClassroomOnly,
+        nameKey: 'tr_auxiliaryClassroomOnly',
+      },
     ],
   },
   {

--- a/src/features/persons/assignments/useAssignments.tsx
+++ b/src/features/persons/assignments/useAssignments.tsx
@@ -181,11 +181,22 @@ const useAssignments = () => {
         views.push(dataView);
       }
 
-      const localItems = items.filter(
-        (record) =>
-          record.code !== AssignmentCode.MM_AssistantOnly &&
-          record.code !== AssignmentCode.MM_AuxiliaryClassroomOnly
+      const hasAssistantOnly = checkedItems.includes(
+        AssignmentCode.MM_AssistantOnly
       );
+      const hasAuxiliaryClassroomOnly = checkedItems.includes(
+        AssignmentCode.MM_AuxiliaryClassroomOnly
+      );
+
+      const isSpecialActive = hasAssistantOnly || hasAuxiliaryClassroomOnly;
+
+      const localItems = items.filter((record) => {
+        const isSpecial =
+          record.code === AssignmentCode.MM_AssistantOnly ||
+          record.code === AssignmentCode.MM_AuxiliaryClassroomOnly;
+
+        return isSpecialActive ? isSpecial : !isSpecial;
+      });
 
       for (const item of localItems) {
         if (!male) {
@@ -222,11 +233,22 @@ const useAssignments = () => {
     }
 
     if (!checked) {
-      const localItems = items.filter(
-        (record) =>
-          record.code !== AssignmentCode.MM_AssistantOnly &&
-          record.code !== AssignmentCode.MM_AuxiliaryClassroomOnly
+      const hasAssistantOnly = checkedItems.includes(
+        AssignmentCode.MM_AssistantOnly
       );
+      const hasAuxiliaryClassroomOnly = checkedItems.includes(
+        AssignmentCode.MM_AuxiliaryClassroomOnly
+      );
+
+      const isSpecialActive = hasAssistantOnly || hasAuxiliaryClassroomOnly;
+
+      const localItems = items.filter((record) => {
+        const isSpecial =
+          record.code === AssignmentCode.MM_AssistantOnly ||
+          record.code === AssignmentCode.MM_AuxiliaryClassroomOnly;
+
+        return isSpecialActive ? isSpecial : !isSpecial;
+      });
 
       for (const item of localItems) {
         if (duplicateAssignmentsGroup.includes(id)) {

--- a/src/features/persons/assignments/useAssignments.tsx
+++ b/src/features/persons/assignments/useAssignments.tsx
@@ -84,6 +84,10 @@ const useAssignments = () => {
             name: t('tr_assistantOnly'),
             borderTop: true,
           },
+          {
+            code: AssignmentCode.MM_AuxiliaryClassroomOnly,
+            name: t('tr_auxiliaryClassroomOnly'),
+          },
         ],
       },
       {
@@ -178,7 +182,9 @@ const useAssignments = () => {
       }
 
       const localItems = items.filter(
-        (record) => record.code !== AssignmentCode.MM_AssistantOnly
+        (record) =>
+          record.code !== AssignmentCode.MM_AssistantOnly &&
+          record.code !== AssignmentCode.MM_AuxiliaryClassroomOnly
       );
 
       for (const item of localItems) {
@@ -216,7 +222,13 @@ const useAssignments = () => {
     }
 
     if (!checked) {
-      for (const item of items) {
+      const localItems = items.filter(
+        (record) =>
+          record.code !== AssignmentCode.MM_AssistantOnly &&
+          record.code !== AssignmentCode.MM_AuxiliaryClassroomOnly
+      );
+
+      for (const item of localItems) {
         if (duplicateAssignmentsGroup.includes(id)) {
           newPerson.person_data.assignments.forEach((assignments) => {
             assignments.updatedAt = new Date().toISOString();

--- a/src/locales/en/congregation.json
+++ b/src/locales/en/congregation.json
@@ -35,6 +35,7 @@
   "tr_overdue": "Overdue",
   "tr_assignments": "Assignments",
   "tr_assistantOnly": "Assistant only",
+  "tr_auxiliaryClassroomOnly": "Auxiliary classroom only",
   "tr_congregationBibleStudyConductor": "Congregation Bible study – conductor",
   "tr_congregationBibleStudyReader": "Congregation Bible study – reader",
   "tr_watchtowerStudyConductor": "Watchtower study – conductor",

--- a/src/services/app/schedules.ts
+++ b/src/services/app/schedules.ts
@@ -1661,8 +1661,52 @@ export const schedulesSelectRandomPerson = (data: {
   let selected: PersonType;
 
   const persons = store.get(personsByViewState);
+  const dataView = store.get(userDataViewState);
 
-  let personsElligible = applyAssignmentFilters(persons, [data.type]);
+  const isAssistant = data.mainStudent && data.mainStudent.length > 0;
+  const filters = [data.type];
+
+  if (isAssistant) {
+    filters.push(AssignmentCode.MM_AssistantOnly);
+  }
+
+  let personsElligible = applyAssignmentFilters(persons, filters);
+
+  if (!isAssistant) {
+    personsElligible = personsElligible.filter((record) => {
+      const activeAssignments =
+        record.person_data.assignments.find((a) => a.type === dataView)
+          ?.values ?? [];
+
+      return !activeAssignments.includes(AssignmentCode.MM_AssistantOnly);
+    });
+  }
+
+  if (data.classroom === '1') {
+    const isStudentPart = [
+      AssignmentCode.MM_BibleReading,
+      AssignmentCode.MM_StartingConversation,
+      AssignmentCode.MM_FollowingUp,
+      AssignmentCode.MM_MakingDisciples,
+      AssignmentCode.MM_ExplainingBeliefs,
+      AssignmentCode.MM_Talk,
+      AssignmentCode.MM_InitialCall,
+      AssignmentCode.MM_ReturnVisit,
+      AssignmentCode.MM_BibleStudy,
+    ].includes(data.type);
+
+    if (isStudentPart) {
+      personsElligible = personsElligible.filter((record) => {
+        const activeAssignments =
+          record.person_data.assignments.find((a) => a.type === dataView)
+            ?.values ?? [];
+
+        return !activeAssignments.includes(
+          AssignmentCode.MM_AuxiliaryClassroomOnly
+        );
+      });
+    }
+  }
 
   if (data.isElderPart) {
     personsElligible = personsElligible.filter((record) =>

--- a/src/services/app/schedules.ts
+++ b/src/services/app/schedules.ts
@@ -1664,49 +1664,42 @@ export const schedulesSelectRandomPerson = (data: {
   const dataView = store.get(userDataViewState);
 
   const isAssistant = data.mainStudent && data.mainStudent.length > 0;
-  const filters = [data.type];
+  const filters = isAssistant
+    ? [data.type, AssignmentCode.MM_AssistantOnly]
+    : [data.type];
 
-  if (isAssistant) {
-    filters.push(AssignmentCode.MM_AssistantOnly);
-  }
-
-  let personsElligible = applyAssignmentFilters(persons, filters);
-
-  if (!isAssistant) {
-    personsElligible = personsElligible.filter((record) => {
-      const activeAssignments =
+  let personsElligible = applyAssignmentFilters(persons, filters).filter(
+    (record) => {
+      const assignments =
         record.person_data.assignments.find((a) => a.type === dataView)
           ?.values ?? [];
 
-      return !activeAssignments.includes(AssignmentCode.MM_AssistantOnly);
-    });
-  }
+      if (!isAssistant && assignments.includes(AssignmentCode.MM_AssistantOnly))
+        return false;
 
-  if (data.classroom === '1') {
-    const isStudentPart = [
-      AssignmentCode.MM_BibleReading,
-      AssignmentCode.MM_StartingConversation,
-      AssignmentCode.MM_FollowingUp,
-      AssignmentCode.MM_MakingDisciples,
-      AssignmentCode.MM_ExplainingBeliefs,
-      AssignmentCode.MM_Talk,
-      AssignmentCode.MM_InitialCall,
-      AssignmentCode.MM_ReturnVisit,
-      AssignmentCode.MM_BibleStudy,
-    ].includes(data.type);
+      const isStudentPart = [
+        AssignmentCode.MM_BibleReading,
+        AssignmentCode.MM_StartingConversation,
+        AssignmentCode.MM_FollowingUp,
+        AssignmentCode.MM_MakingDisciples,
+        AssignmentCode.MM_ExplainingBeliefs,
+        AssignmentCode.MM_Talk,
+        AssignmentCode.MM_InitialCall,
+        AssignmentCode.MM_ReturnVisit,
+        AssignmentCode.MM_BibleStudy,
+      ].includes(data.type);
 
-    if (isStudentPart) {
-      personsElligible = personsElligible.filter((record) => {
-        const activeAssignments =
-          record.person_data.assignments.find((a) => a.type === dataView)
-            ?.values ?? [];
+      if (
+        data.classroom === '1' &&
+        isStudentPart &&
+        assignments.includes(AssignmentCode.MM_AuxiliaryClassroomOnly)
+      ) {
+        return false;
+      }
 
-        return !activeAssignments.includes(
-          AssignmentCode.MM_AuxiliaryClassroomOnly
-        );
-      });
+      return true;
     }
-  }
+  );
 
   if (data.isElderPart) {
     personsElligible = personsElligible.filter((record) =>

--- a/src/services/app/schedules.ts
+++ b/src/services/app/schedules.ts
@@ -1691,49 +1691,42 @@ export const schedulesSelectRandomPerson = (data: {
   const dataView = store.get(userDataViewState);
 
   const isAssistant = data.mainStudent && data.mainStudent.length > 0;
-  const filters = [data.type];
+  const filters = isAssistant
+    ? [data.type, AssignmentCode.MM_AssistantOnly]
+    : [data.type];
 
-  if (isAssistant) {
-    filters.push(AssignmentCode.MM_AssistantOnly);
-  }
-
-  let personsElligible = applyAssignmentFilters(persons, filters);
-
-  if (!isAssistant) {
-    personsElligible = personsElligible.filter((record) => {
-      const activeAssignments =
+  let personsElligible = applyAssignmentFilters(persons, filters).filter(
+    (record) => {
+      const assignments =
         record.person_data.assignments.find((a) => a.type === dataView)
           ?.values ?? [];
 
-      return !activeAssignments.includes(AssignmentCode.MM_AssistantOnly);
-    });
-  }
+      if (!isAssistant && assignments.includes(AssignmentCode.MM_AssistantOnly))
+        return false;
 
-  if (data.classroom === '1') {
-    const isStudentPart = [
-      AssignmentCode.MM_BibleReading,
-      AssignmentCode.MM_StartingConversation,
-      AssignmentCode.MM_FollowingUp,
-      AssignmentCode.MM_MakingDisciples,
-      AssignmentCode.MM_ExplainingBeliefs,
-      AssignmentCode.MM_Talk,
-      AssignmentCode.MM_InitialCall,
-      AssignmentCode.MM_ReturnVisit,
-      AssignmentCode.MM_BibleStudy,
-    ].includes(data.type);
+      const isStudentPart = [
+        AssignmentCode.MM_BibleReading,
+        AssignmentCode.MM_StartingConversation,
+        AssignmentCode.MM_FollowingUp,
+        AssignmentCode.MM_MakingDisciples,
+        AssignmentCode.MM_ExplainingBeliefs,
+        AssignmentCode.MM_Talk,
+        AssignmentCode.MM_InitialCall,
+        AssignmentCode.MM_ReturnVisit,
+        AssignmentCode.MM_BibleStudy,
+      ].includes(data.type);
 
-    if (isStudentPart) {
-      personsElligible = personsElligible.filter((record) => {
-        const activeAssignments =
-          record.person_data.assignments.find((a) => a.type === dataView)
-            ?.values ?? [];
+      if (
+        data.classroom === '1' &&
+        isStudentPart &&
+        assignments.includes(AssignmentCode.MM_AuxiliaryClassroomOnly)
+      ) {
+        return false;
+      }
 
-        return !activeAssignments.includes(
-          AssignmentCode.MM_AuxiliaryClassroomOnly
-        );
-      });
+      return true;
     }
-  }
+  );
 
   const { date: meetingDate } = schedulesGetMeetingDate({
     week: data.week,

--- a/src/services/app/schedules.ts
+++ b/src/services/app/schedules.ts
@@ -1688,8 +1688,52 @@ export const schedulesSelectRandomPerson = (data: {
   let selected: PersonType;
 
   const persons = store.get(personsByViewState);
+  const dataView = store.get(userDataViewState);
 
-  let personsElligible = applyAssignmentFilters(persons, [data.type]);
+  const isAssistant = data.mainStudent && data.mainStudent.length > 0;
+  const filters = [data.type];
+
+  if (isAssistant) {
+    filters.push(AssignmentCode.MM_AssistantOnly);
+  }
+
+  let personsElligible = applyAssignmentFilters(persons, filters);
+
+  if (!isAssistant) {
+    personsElligible = personsElligible.filter((record) => {
+      const activeAssignments =
+        record.person_data.assignments.find((a) => a.type === dataView)
+          ?.values ?? [];
+
+      return !activeAssignments.includes(AssignmentCode.MM_AssistantOnly);
+    });
+  }
+
+  if (data.classroom === '1') {
+    const isStudentPart = [
+      AssignmentCode.MM_BibleReading,
+      AssignmentCode.MM_StartingConversation,
+      AssignmentCode.MM_FollowingUp,
+      AssignmentCode.MM_MakingDisciples,
+      AssignmentCode.MM_ExplainingBeliefs,
+      AssignmentCode.MM_Talk,
+      AssignmentCode.MM_InitialCall,
+      AssignmentCode.MM_ReturnVisit,
+      AssignmentCode.MM_BibleStudy,
+    ].includes(data.type);
+
+    if (isStudentPart) {
+      personsElligible = personsElligible.filter((record) => {
+        const activeAssignments =
+          record.person_data.assignments.find((a) => a.type === dataView)
+            ?.values ?? [];
+
+        return !activeAssignments.includes(
+          AssignmentCode.MM_AuxiliaryClassroomOnly
+        );
+      });
+    }
+  }
 
   const { date: meetingDate } = schedulesGetMeetingDate({
     week: data.week,


### PR DESCRIPTION
Finalized the 'Auxiliary classroom only' qualification with the following refinements:

1. **Mutual Exclusivity Logic**: Replaced the custom 'special' prop with the standardized mutual-exclusivity pattern. 'Auxiliary classroom only' now correctly dims when core student assignments are checked, and vice versa—identical to the 'Assistant only' behavior.
2. **Context-Aware Header**: The section header now automatically targets the currently enabled group (Core vs Special). If only the bottom group is active, the header toggles those items specifically.
3. **Indeterminate State Fix**: The section header no longer shows a 'minus' sign when only the optional qualifications are selected, preventing visual confusion.
4. **Styling Consistency**: Ensured font size, text color, and icon style match perfectly across all assignment types.
5. **Gender Compatibility**: Verified functionality for both brothers and sisters.

Implementation refined based on existing project patterns for 'Assistant only' qualifications.