### PR TITLE
fix(styles): prevent italic font in tooltips globally

### DIFF
--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -40,9 +40,16 @@ const Tooltip: FC<CustomTooltipProps> = ({
 
   if (!show) return <>{children}</>;
 
+  const displayTitle =
+    typeof title === 'string' || typeof title === 'number' ? (
+      <Box component="span" sx={{ fontStyle: 'normal !important', fontFamily: 'inherit' }}>{title}</Box>
+    ) : (
+      title
+    );
+
   return (
     <MUITooltip
-      title={title}
+      title={displayTitle}
       followCursor={followCursor}
       enterDelay={getEnterDelay()}
       slots={{ transition: Grow }}
@@ -55,7 +62,7 @@ const Tooltip: FC<CustomTooltipProps> = ({
             maxWidth: '360px',
             color: 'var(--white)',
             fontSize: '12px',
-            fontStyle: 'normal',
+            fontStyle: 'normal !important',
             border: 'none',
           },
         },


### PR DESCRIPTION
# Description

This PR fixes an issue where tooltips were displayed with an italic font style across various browsers and themes. The fix involves wrapping the tooltip title in an MUI Box component with an explicit \`fontStyle: 'normal !important'\` style applied via the \`sx\` prop. This ensures that the text remains non-italicized regardless of inherited styles or theme variants.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
