### PR TITLE
fix(ui): adjust mobile search and filter layout in persons list

### DIFF
--- a/src/components/search_bar/search_bar.styled.tsx
+++ b/src/components/search_bar/search_bar.styled.tsx
@@ -31,13 +31,21 @@ export const StyledInput = styled(Input)({
   flex: '1 0 0',
   alignSelf: 'stretch',
   borderRadius: 'var(--radius-none)',
+  minWidth: 0,
 
   '& .MuiInput-input::placeholder': {
     color: 'var(--grey-350)',
     opacity: 1,
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
   },
 
   '& input': {
     color: 'var(--black)',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    minWidth: 0,
   },
 });

--- a/src/pages/persons/all_persons/index.tsx
+++ b/src/pages/persons/all_persons/index.tsx
@@ -91,10 +91,14 @@ const PersonsAll = () => {
               flexDirection: 'column',
             }}
           >
-            <Box sx={{ display: 'flex', gap: '16px' }}>
-              <PersonsSearch />
+            <Box sx={{ display: 'flex', gap: '16px', alignItems: 'flex-start' }}>
+              <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                <PersonsSearch />
+              </Box>
               <Button
                 variant="secondary"
+                disableAutoStretch
+                sx={{ flexShrink: 0, height: '48px', padding: '8px 16px' }}
                 onClick={() => setIsPanelOpen((prev) => !prev)}
                 endIcon={isPanelOpen ? <IconPanelOpen /> : <IconPanelClose />}
               >
@@ -129,10 +133,14 @@ const PersonsAll = () => {
                     flexDirection: 'column',
                   }}
                 >
-                  <Box sx={{ display: 'flex', gap: '16px' }}>
-                    <PersonsSearch />
+                  <Box sx={{ display: 'flex', gap: '16px', alignItems: 'flex-start' }}>
+                    <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                      <PersonsSearch />
+                    </Box>
                     <Button
                       variant="secondary"
+                      disableAutoStretch
+                      sx={{ flexShrink: 0, height: '48px', padding: '8px 16px' }}
                       onClick={() => setIsPanelOpen((prev) => !prev)}
                       endIcon={
                         isPanelOpen ? <IconPanelOpen /> : <IconPanelClose />


### PR DESCRIPTION
# Description

Fixes the mobile and multi-language layout issue on the Persons Search page where the \"Search by name\" bar and the \"Filters\" button would divide the available space 50/50, causing awkward text wrapping and squished search bars.

Specifically:
- **UI Fix**: Resolved the 50/50 split bug on mobile by using a bulletproof flexbox layout (`min-width: 0` on search and `flex-shrink: 0` on the button) in both Desktop and Mobile views.
- **Multi-language Support**: Added `text-overflow: ellipsis` to the `SearchBar` component so long placeholders/values truncate gracefully on narrow screens.
- **Auto-stretch Fix**: Passed `disableAutoStretch` to the Filter button to prevent it from taking 100% width on mobile devices.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings