### PR TITLE
fix(reports): allow deselecting Bible studies by clicking in the selector list

### DIFF
--- a/src/features/ministry/report/bible_study_selector/bible_study_item/index.tsx
+++ b/src/features/ministry/report/bible_study_selector/bible_study_item/index.tsx
@@ -7,12 +7,12 @@ import Typography from '@components/typography';
 import IconButton from '@components/icon_button';
 
 const BibleStudyItem = (props: BibleStudyItemProps) => {
-  const { handleEditStudy, handleSelectStudy } = useBibleStudyItem(props);
+  const { handleEditStudy, handleToggleStudy } = useBibleStudyItem(props);
 
   return (
     <MenuItem
       sx={{ height: '40px', minHeight: '40px' }}
-      onClick={props.selected ? null : handleSelectStudy}
+      onClick={handleToggleStudy}
     >
       <Box
         sx={{

--- a/src/features/ministry/report/bible_study_selector/bible_study_item/index.types.ts
+++ b/src/features/ministry/report/bible_study_selector/bible_study_item/index.types.ts
@@ -4,5 +4,5 @@ export type BibleStudyItemProps = {
   bibleStudy: UserBibleStudyType;
   onEdit: (study: UserBibleStudyType) => void;
   selected: boolean;
-  onSelect: (study: UserBibleStudyType) => void;
+  onToggle: (study: UserBibleStudyType) => void;
 };

--- a/src/features/ministry/report/bible_study_selector/bible_study_item/useBibleStudyItem.tsx
+++ b/src/features/ministry/report/bible_study_selector/bible_study_item/useBibleStudyItem.tsx
@@ -1,22 +1,18 @@
 import { MouseEvent } from 'react';
 import { BibleStudyItemProps } from './index.types';
 
-const useBibleStudyItem = ({
-  bibleStudy,
-  onEdit,
-  onSelect,
-}: BibleStudyItemProps) => {
+const useBibleStudyItem = ({ bibleStudy, onEdit, onToggle }: BibleStudyItemProps) => {
   const handleEditStudy = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     onEdit(bibleStudy);
   };
 
-  const handleSelectStudy = (e: MouseEvent<HTMLLIElement>) => {
+  const handleToggleStudy = (e: MouseEvent<HTMLLIElement>) => {
     e.currentTarget.blur();
-    onSelect(bibleStudy);
+    onToggle(bibleStudy);
   };
 
-  return { handleEditStudy, handleSelectStudy };
+  return { handleEditStudy, handleToggleStudy };
 };
 
 export default useBibleStudyItem;

--- a/src/features/ministry/report/bible_study_selector/index.tsx
+++ b/src/features/ministry/report/bible_study_selector/index.tsx
@@ -20,7 +20,7 @@ const BibleStudySelector = (props: BibleStudySelectorProps) => {
     handleCloseEditor,
     bibleStudy,
     handleEditBibleStudy,
-    handleSelectBibleStudy,
+    handleToggleBibleStudy,
   } = useBibleSelector(props);
 
   return (
@@ -83,15 +83,19 @@ const BibleStudySelector = (props: BibleStudySelectorProps) => {
             },
           }}
         >
-          {bibleStudies.map((study) => (
-            <BibleStudyItem
-              key={study.person_uid}
-              bibleStudy={study}
-              onEdit={handleEditBibleStudy}
-              selected={props.handleCheckSelected(study)}
-              onSelect={(study) => handleSelectBibleStudy(study)}
-            />
-          ))}
+          {bibleStudies.map((study) => {
+            const selected = props.handleCheckSelected(study);
+
+            return (
+              <BibleStudyItem
+                key={study.person_uid}
+                bibleStudy={study}
+                onEdit={handleEditBibleStudy}
+                selected={selected}
+                onToggle={() => handleToggleBibleStudy(study, selected)}
+              />
+            );
+          })}
 
           <MenuItem
             onClick={handleAddNewBibleStudy}

--- a/src/features/ministry/report/bible_study_selector/index.types.ts
+++ b/src/features/ministry/report/bible_study_selector/index.types.ts
@@ -5,5 +5,6 @@ export type BibleStudySelectorProps = {
   anchorEl: MutableRefObject<Element>;
   editable: boolean;
   handleCheckSelected: (study: UserBibleStudyType) => boolean;
-  onChange: (study: UserBibleStudyType) => void;
+  onSelect: (study: UserBibleStudyType) => void;
+  onDeselect: (study: UserBibleStudyType) => void;
 };

--- a/src/features/ministry/report/bible_study_selector/useBibleSelector.tsx
+++ b/src/features/ministry/report/bible_study_selector/useBibleSelector.tsx
@@ -4,7 +4,7 @@ import { UserBibleStudyType } from '@definition/user_bible_studies';
 import { userBibleStudiesState } from '@states/user_bible_studies';
 import { BibleStudySelectorProps } from './index.types';
 
-const useBibleSelector = ({ onChange }: BibleStudySelectorProps) => {
+const useBibleSelector = ({ onSelect, onDeselect }: BibleStudySelectorProps) => {
   const bibleStudiesAll = useAtomValue(userBibleStudiesState);
 
   const [selectorOpen, setSelectorOpen] = useState(false);
@@ -39,9 +39,17 @@ const useBibleSelector = ({ onChange }: BibleStudySelectorProps) => {
     handleAddNewBibleStudy();
   };
 
-  const handleSelectBibleStudy = (study: UserBibleStudyType) => {
+  const handleToggleBibleStudy = (
+    study: UserBibleStudyType,
+    selected: boolean
+  ) => {
     setSelectorOpen(false);
-    onChange(study);
+
+    if (selected) {
+      onDeselect(study);
+    } else {
+      onSelect(study);
+    }
   };
 
   return {
@@ -53,7 +61,7 @@ const useBibleSelector = ({ onChange }: BibleStudySelectorProps) => {
     handleCloseEditor,
     bibleStudy,
     handleEditBibleStudy,
-    handleSelectBibleStudy,
+    handleToggleBibleStudy,
   };
 };
 

--- a/src/features/ministry/report/form_S4/bible_studies/index.tsx
+++ b/src/features/ministry/report/form_S4/bible_studies/index.tsx
@@ -51,7 +51,8 @@ const BibleStudies = (props: FormS4Props) => {
             anchorEl={bibleStudyRef}
             editable={locked ? false : props.publisher && isSelf}
             handleCheckSelected={handleCheckSelected}
-            onChange={handleBibleStudyRecordsChange}
+            onSelect={handleBibleStudyRecordsChange}
+            onDeselect={handleBibleStudyDelete}
           />
         )}
 

--- a/src/features/ministry/report/report_form_dialog/service_time/index.tsx
+++ b/src/features/ministry/report/report_form_dialog/service_time/index.tsx
@@ -37,6 +37,7 @@ const ServiceTime = (props: ServiceTimeProps) => {
     handleDeleteReport,
     handleCheckSelected,
     handleSelectStudy,
+    handleDeselectStudy,
     hours_field,
   } = useServiceTime(props);
 
@@ -139,7 +140,8 @@ const ServiceTime = (props: ServiceTimeProps) => {
             anchorEl={bibleStudyRef}
             editable={true}
             handleCheckSelected={handleCheckSelected}
-            onChange={handleSelectStudy}
+            onSelect={handleSelectStudy}
+            onDeselect={handleDeselectStudy}
           />
 
           <StandardEditor

--- a/src/features/ministry/report/report_form_dialog/service_time/useServiceTime.tsx
+++ b/src/features/ministry/report/report_form_dialog/service_time/useServiceTime.tsx
@@ -178,6 +178,22 @@ const useServiceTime = ({ onClose }: ServiceTimeProps) => {
     setCurrentReport(report);
   };
 
+  const handleDeselectStudy = (study: UserBibleStudyType) => {
+    const report = structuredClone(currentReport);
+
+    report.report_data.bible_studies.records =
+      report.report_data.bible_studies.records.filter(
+        (record) => record !== study.person_uid
+      );
+
+    const cnCount = report.report_data.bible_studies.value;
+    report.report_data.bible_studies.value = cnCount - 1;
+
+    report.report_data.updatedAt = new Date().toISOString();
+
+    setCurrentReport(report);
+  };
+
   return {
     bibleStudyRef,
     hours_field,
@@ -195,6 +211,7 @@ const useServiceTime = ({ onClose }: ServiceTimeProps) => {
     handleDeleteReport,
     handleCheckSelected,
     handleSelectStudy,
+    handleDeselectStudy,
   };
 };
 


### PR DESCRIPTION
# Description

Previously, once a Bible study was selected from the dropdown selector list, it could only be removed by closing the blue chip (×). Clicking the same study in the list again had no effect.

This change adds a simple toggle behavior: clicking an already-selected Bible study in the dropdown deselects it — removing the chip and decrementing the count. This works in both the daily "Add Service Time" dialog and the monthly Ministry Report (S4) page.

Additionally, the selector's internal API has been cleaned up:
- Renamed `onChange` → `onSelect` for symmetry with the new `onDeselect`
- Merged duplicate `onSelect`/`onDeselect` item-level props into a single `onToggle`
- Consolidated redundant handler functions in `useBibleStudyItem` and `useBibleSelector`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings