### PR TITLE
fix(autofill): away time not respected by autofill for meeting assignments

### DIFF
--- a/src/services/app/autofill.ts
+++ b/src/services/app/autofill.ts
@@ -91,6 +91,7 @@ const handleMMAssignChairman = (
       selected = schedulesSelectRandomPerson({
         type: AssignmentCode.MM_Chairman,
         week: schedule.weekOf,
+        meeting: 'midweek',
         history: historyAutofill,
       });
 
@@ -122,6 +123,7 @@ const handleMMAssignChairman = (
         selected = schedulesSelectRandomPerson({
           type: AssignmentCode.MM_AuxiliaryCounselor,
           week: schedule.weekOf,
+          meeting: 'midweek',
           history: historyAutofill,
         });
 
@@ -178,6 +180,7 @@ const handleMMAssignCBSConductor = (
       selected = schedulesSelectRandomPerson({
         type: AssignmentCode.MM_CBSConductor,
         week: schedule.weekOf,
+        meeting: 'midweek',
         history: historyAutofill,
       });
 
@@ -210,6 +213,7 @@ const handleMMAssignTGWTalk = (
     selected = schedulesSelectRandomPerson({
       type: AssignmentCode.MM_TGWTalk,
       week: schedule.weekOf,
+      meeting: 'midweek',
       history: historyAutofill,
     });
     if (selected) {
@@ -240,6 +244,7 @@ const handleMMAssignTGWGems = (
     selected = schedulesSelectRandomPerson({
       type: AssignmentCode.MM_TGWGems,
       week: schedule.weekOf,
+      meeting: 'midweek',
       history: historyAutofill,
     });
     if (selected) {
@@ -303,6 +308,7 @@ const handleMMAssignLCStandard = (
         selected = schedulesSelectRandomPerson({
           type: AssignmentCode.MM_LCPart,
           week: schedule.weekOf,
+          meeting: 'midweek',
           isElderPart,
           history: historyAutofill,
         });
@@ -358,6 +364,7 @@ const handleMMAssignLCCustom = (
         selected = schedulesSelectRandomPerson({
           type: AssignmentCode.MM_LCPart,
           week: schedule.weekOf,
+          meeting: 'midweek',
           isElderPart,
           history: historyAutofill,
         });
@@ -404,6 +411,7 @@ const handleMMAssignCBSReader = (
       selected = schedulesSelectRandomPerson({
         type: AssignmentCode.MM_CBSReader,
         week: schedule.weekOf,
+        meeting: 'midweek',
         history: historyAutofill,
       });
 
@@ -439,6 +447,7 @@ const handleMMAssignPrayer = (
     selected = schedulesSelectRandomPerson({
       type: AssignmentCode.MM_Prayer,
       week: schedule.weekOf,
+      meeting: 'midweek',
       history: historyAutofill,
     });
 
@@ -476,6 +485,7 @@ const handleMMAssignBibleReading = (
     selected = schedulesSelectRandomPerson({
       type: AssignmentCode.MM_BibleReading,
       week: schedule.weekOf,
+      meeting: 'midweek',
       classroom: classroom,
       history: historyAutofill,
     });
@@ -559,6 +569,7 @@ const handleMMAssignAYFStudent = (
           selected = schedulesSelectRandomPerson({
             type,
             week: schedule.weekOf,
+            meeting: 'midweek',
             isAYFTalk: isTalk,
             classroom: '1',
             history: historyAutofill,
@@ -584,6 +595,7 @@ const handleMMAssignAYFStudent = (
           selected = schedulesSelectRandomPerson({
             type,
             week: schedule.weekOf,
+            meeting: 'midweek',
             isAYFTalk: isTalk,
             classroom: '2',
             history: historyAutofill,
@@ -665,6 +677,7 @@ const handleMMAssignAYFAssistant = (
           selected = schedulesSelectRandomPerson({
             type,
             week: schedule.weekOf,
+            meeting: 'midweek',
             mainStudent,
             isAYFTalk: isTalk,
             classroom: '1',
@@ -701,6 +714,7 @@ const handleMMAssignAYFAssistant = (
           selected = schedulesSelectRandomPerson({
             type,
             week: schedule.weekOf,
+            meeting: 'midweek',
             mainStudent,
             isAYFTalk: isTalk,
             classroom: '2',
@@ -873,6 +887,7 @@ const handleWMAssignSpeaker = (
       selected = schedulesSelectRandomPerson({
         type: AssignmentCode.WM_SpeakerSymposium,
         week: schedule.weekOf,
+        meeting: 'weekend',
         history: historyAutofill,
       });
 
@@ -907,6 +922,7 @@ const handleWMAssignSpeaker = (
           selected = schedulesSelectRandomPerson({
             type: AssignmentCode.WM_Speaker,
             week: schedule.weekOf,
+            meeting: 'weekend',
             history: historyAutofill,
           });
 
@@ -943,6 +959,7 @@ const handleWMAssignChairman = (
     selected = schedulesSelectRandomPerson({
       type: AssignmentCode.WM_Chairman,
       week: schedule.weekOf,
+      meeting: 'weekend',
       history: historyAutofill,
     });
 
@@ -975,6 +992,7 @@ const handleWMAssignPrayer = (
     selected = schedulesSelectRandomPerson({
       type: AssignmentCode.WM_Prayer,
       week: schedule.weekOf,
+      meeting: 'weekend',
       history: historyAutofill,
     });
 
@@ -1007,6 +1025,7 @@ const handleWMStudyReader = (
     selected = schedulesSelectRandomPerson({
       type: AssignmentCode.WM_WTStudyReader,
       week: schedule.weekOf,
+      meeting: 'weekend',
       history: historyAutofill,
     });
 

--- a/src/services/app/schedules.ts
+++ b/src/services/app/schedules.ts
@@ -1651,6 +1651,7 @@ export const schedulesPersonLatest = ({
 export const schedulesSelectRandomPerson = (data: {
   type: AssignmentCode;
   week: string;
+  meeting: 'midweek' | 'weekend';
   isAYFTalk?: boolean;
   classroom?: string;
   isLC?: boolean;
@@ -1664,9 +1665,13 @@ export const schedulesSelectRandomPerson = (data: {
 
   let personsElligible = applyAssignmentFilters(persons, [data.type]);
 
-  // Exclude persons who are marked as away during the meeting week
+  const { date: meetingDate } = schedulesGetMeetingDate({
+    week: data.week,
+    meeting: data.meeting,
+  });
+
   personsElligible = personsElligible.filter(
-    (record) => !personIsAway(record, data.week)
+    (record) => !personIsAway(record, meetingDate || data.week)
   );
 
   if (data.isElderPart) {

--- a/src/services/app/schedules.ts
+++ b/src/services/app/schedules.ts
@@ -87,7 +87,7 @@ import {
   generateDateFromTime,
   timeAddMinutes,
 } from '@utils/date';
-import { applyAssignmentFilters, personIsElder } from './persons';
+import { applyAssignmentFilters, personIsAway, personIsElder } from './persons';
 import { personsByViewState } from '@states/persons';
 import { personsStateFind } from '@services/states/persons';
 import { buildPersonFullname, personGetDisplayName } from '@utils/common';
@@ -1663,6 +1663,11 @@ export const schedulesSelectRandomPerson = (data: {
   const persons = store.get(personsByViewState);
 
   let personsElligible = applyAssignmentFilters(persons, [data.type]);
+
+  // Exclude persons who are marked as away during the meeting week
+  personsElligible = personsElligible.filter(
+    (record) => !personIsAway(record, data.week)
+  );
 
   if (data.isElderPart) {
     personsElligible = personsElligible.filter((record) =>


### PR DESCRIPTION
## Description

Fixes #5169

When using Autofill for meeting assignments, publishers marked as away (time away / vacation) were still being selected and assigned, showing a warning after the fact. The only workaround was manually removing their privileges.

- **Root cause:** `schedulesSelectRandomPerson` in `src/services/app/schedules.ts` never checked a person's `timeAway` data. The manual person selectors (`useBrotherSelector`, `useStudentSelector`) correctly called `personIsAway()` to show the away warning, but the autofill path bypassed this check entirely.
- **Fix:** Added a filter step in `schedulesSelectRandomPerson` that excludes any person whose away period overlaps the target meeting date, using the already-existing `personIsAway()` utility from `./persons`.

**Additional precision fix** (noticed during CodeRabbit AI review):  
The initial filter used `data.week` (the Monday week anchor, e.g. `2026/05/04`) instead of the actual meeting date. Since `personIsAway` does a strict date range check (`startDate <= date`), an away period starting on Tuesday would not be caught when checking Monday. The filter now uses `schedulesGetMeetingDate()` — the same utility already used by the manual selectors — to resolve the real meeting day (e.g. Tuesday for midweek, Saturday for weekend) before checking away status. The `meeting` type param was added to `schedulesSelectRandomPerson` and all call sites in `autofill.ts` updated accordingly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings