### PR TITLE
fix(header): make the rightmost button always blue

### DIFF
--- a/src/components/nav_bar_button_group/index.tsx
+++ b/src/components/nav_bar_button_group/index.tsx
@@ -1,0 +1,49 @@
+import {
+  Children,
+  cloneElement,
+  Fragment,
+  isValidElement,
+  ReactElement,
+  ReactNode,
+} from 'react';
+
+// Children.toArray does not expand Fragment elements, so conditional patterns
+// like {cond && <><A /><B /></>} would hide A and B from analysis.
+// This recursive helper expands all fragments into a flat element list.
+const flattenChildren = (children: ReactNode): ReactElement[] => {
+  return Children.toArray(children).flatMap((child) => {
+    if (!isValidElement(child)) return [];
+    if (child.type === Fragment) {
+      return flattenChildren((child.props as { children: ReactNode }).children);
+    }
+    return [child];
+  });
+};
+
+/**
+ * Automatically promotes the last visible child to the "main" (filled)
+ * variant, so there is always a prominent primary action regardless of which
+ * buttons are conditionally rendered for the current user.
+ *
+ * Works with both direct NavBarButton elements and wrapper components that
+ * forward the `main` prop to their internal NavBarButton.
+ */
+const NavBarButtonGroup = ({ children }: { children: ReactNode }) => {
+  const flatChildren = flattenChildren(children);
+
+  if (flatChildren.length === 0) return null;
+
+  const lastIndex = flatChildren.length - 1;
+
+  return (
+    <>
+      {flatChildren.map((child, i) =>
+        cloneElement(child as ReactElement<{ main?: boolean }>, {
+          main: i === lastIndex,
+        })
+      )}
+    </>
+  );
+};
+
+export default NavBarButtonGroup;

--- a/src/features/activities/upcoming_events/export_upcoming_events/index.tsx
+++ b/src/features/activities/upcoming_events/export_upcoming_events/index.tsx
@@ -4,13 +4,14 @@ import IconLoading from '@components/icon_loading';
 import useExportUpcomingEvents from './useExportUpcomingEvents';
 import NavBarButton from '@components/nav_bar_button';
 
-const ExportUpcomingEvents = () => {
+const ExportUpcomingEvents = ({ main }: { main?: boolean }) => {
   const { t } = useAppTranslation();
   const { isProcessing, handleExport } = useExportUpcomingEvents();
 
   return (
     <NavBarButton
       text={t('tr_export')}
+      main={main}
       icon={
         isProcessing ? (
           <IconLoading color="var(--accent-main)" />

--- a/src/features/congregation/field_service_groups/export_groups/index.tsx
+++ b/src/features/congregation/field_service_groups/export_groups/index.tsx
@@ -4,7 +4,7 @@ import { useAppTranslation } from '@hooks/index';
 import useExportGroups from './useExportGroups';
 import NavBarButton from '@components/nav_bar_button';
 
-const ExportGroups = () => {
+const ExportGroups = ({ main }: { main?: boolean }) => {
   const { t } = useAppTranslation();
 
   const { handleExport, isProcessing } = useExportGroups();
@@ -12,6 +12,7 @@ const ExportGroups = () => {
   return (
     <NavBarButton
       text={t('tr_export')}
+      main={main}
       onClick={handleExport}
       icon={
         isProcessing ? (

--- a/src/features/ministry/ap_application/submit_application/index.tsx
+++ b/src/features/ministry/ap_application/submit_application/index.tsx
@@ -4,7 +4,7 @@ import { useAppTranslation } from '@hooks/index';
 import useSubmitApplication from './useSubmitApplication';
 import NavBarButton from '@components/nav_bar_button';
 
-const SubmitApplication = () => {
+const SubmitApplication = ({ main }: { main?: boolean }) => {
   const { t } = useAppTranslation();
 
   const { disabled, handleSubmit, isProcessing } = useSubmitApplication();
@@ -12,7 +12,7 @@ const SubmitApplication = () => {
   return (
     <NavBarButton
       text={t('tr_btnSubmit')}
-      main
+      main={main}
       icon={isProcessing ? <IconLoading /> : <IconSend />}
       disabled={disabled || isProcessing}
       onClick={handleSubmit}
@@ -21,3 +21,4 @@ const SubmitApplication = () => {
 };
 
 export default SubmitApplication;
+

--- a/src/features/persons/button_actions/index.tsx
+++ b/src/features/persons/button_actions/index.tsx
@@ -4,6 +4,7 @@ import useButtonActions from './useButtonActions';
 import PersonDisqualifyConfirm from '../disqualify';
 import PersonQualifyConfirm from '../qualify';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const PersonButtonActions = () => {
   const { t } = useAppTranslation();
@@ -28,7 +29,7 @@ const PersonButtonActions = () => {
   return (
     <>
       {isPersonEditor && (
-        <>
+        <NavBarButtonGroup>
           <PersonDisqualifyConfirm
             open={isDisqualify}
             onClose={handleDisqualifyCancel}
@@ -60,11 +61,10 @@ const PersonButtonActions = () => {
 
           <NavBarButton
             text={t('tr_save')}
-            main
             icon={<IconSave />}
             onClick={handleSavePerson}
           ></NavBarButton>
-        </>
+        </NavBarButtonGroup>
       )}
     </>
   );

--- a/src/features/reports/meeting_attendance/export_S88/index.tsx
+++ b/src/features/reports/meeting_attendance/export_S88/index.tsx
@@ -4,7 +4,7 @@ import IconLoading from '@components/icon_loading';
 import useExportS88 from './useExportS88';
 import NavBarButton from '@components/nav_bar_button';
 
-const ExportS88 = () => {
+const ExportS88 = ({ main }: { main?: boolean }) => {
   const { t } = useAppTranslation();
 
   const { handleExportS88, isProcessing } = useExportS88();
@@ -12,7 +12,7 @@ const ExportS88 = () => {
   return (
     <NavBarButton
       text={t('tr_export')}
-      main
+      main={main}
       onClick={handleExportS88}
       icon={isProcessing ? <IconLoading /> : <IconExport />}
       disabled={isProcessing}
@@ -21,3 +21,4 @@ const ExportS88 = () => {
 };
 
 export default ExportS88;
+

--- a/src/features/reports/publisher_records_details/export_S21/index.tsx
+++ b/src/features/reports/publisher_records_details/export_S21/index.tsx
@@ -4,7 +4,7 @@ import { useAppTranslation } from '@hooks/index';
 import useExportS21 from './useExportS21';
 import NavBarButton from '@components/nav_bar_button';
 
-const ExportS21 = () => {
+const ExportS21 = ({ main }: { main?: boolean }) => {
   const { t } = useAppTranslation();
 
   const { handleExport, isProcessing } = useExportS21();
@@ -12,6 +12,7 @@ const ExportS21 = () => {
   return (
     <NavBarButton
       text={t('tr_exportS21')}
+      main={main}
       onClick={handleExport}
       disabled={isProcessing}
       icon={isProcessing ? <IconLoading /> : <IconExport />}

--- a/src/pages/activities/upcoming_events/index.tsx
+++ b/src/pages/activities/upcoming_events/index.tsx
@@ -7,6 +7,7 @@ import PageTitle from '@components/page_title';
 import UpcomingEventsList from '@features/activities/upcoming_events/upcoming_events_list';
 import ExportUpcomingEvents from '@features/activities/upcoming_events/export_upcoming_events';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const UpcomingEvents = () => {
   const { t } = useAppTranslation();
@@ -35,15 +36,14 @@ const UpcomingEvents = () => {
         title={t('tr_upcomingEvents')}
         buttons={
           isAdmin && (
-            <>
+            <NavBarButtonGroup>
               <ExportUpcomingEvents />
               <NavBarButton
-                main
                 text={t('tr_add')}
                 icon={<IconAdd />}
                 onClick={handleAddEventButtonClick}
               ></NavBarButton>
-            </>
+            </NavBarButtonGroup>
           )
         }
       />

--- a/src/pages/congregation/field_service_groups/useFieldServiceGroups.tsx
+++ b/src/pages/congregation/field_service_groups/useFieldServiceGroups.tsx
@@ -6,6 +6,7 @@ import { fieldGroupsState } from '@states/field_service_groups';
 import ExportGroups from '@features/congregation/field_service_groups/export_groups';
 import { displaySnackNotification } from '@services/states/app';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const useFieldServiceGroups = () => {
   const { t } = useAppTranslation();
@@ -44,7 +45,7 @@ const useFieldServiceGroups = () => {
     if (!isServiceCommittee) return <></>;
 
     return (
-      <>
+      <NavBarButtonGroup>
         {groups.length > 0 && <ExportGroups />}
 
         {groups.length > 1 && (
@@ -57,11 +58,10 @@ const useFieldServiceGroups = () => {
 
         <NavBarButton
           text={t('tr_btnAdd')}
-          main
           onClick={handleOpenGroupAdd}
           icon={<IconAdd />}
         ></NavBarButton>
-      </>
+      </NavBarButtonGroup>
     );
   }, [isServiceCommittee, groups.length, t, handleOpenGroupAdd]);
 

--- a/src/pages/congregation/manage_access/all_users/index.tsx
+++ b/src/pages/congregation/manage_access/all_users/index.tsx
@@ -7,6 +7,7 @@ import CongregationVIP from '@features/congregation/app_access/congregation_vip'
 import PageTitle from '@components/page_title';
 import UserAdd from '@features/congregation/app_access/user_add';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const UsersAll = () => {
   const { t } = useAppTranslation();
@@ -28,12 +29,13 @@ const UsersAll = () => {
       <PageTitle
         title={t('tr_manageAccessFullTitle')}
         buttons={
-          <NavBarButton
-            text={t('tr_btnAdd')}
-            main
-            icon={<IconAddPerson />}
-            onClick={handleOpenUserAdd}
-          ></NavBarButton>
+          <NavBarButtonGroup>
+            <NavBarButton
+              text={t('tr_btnAdd')}
+              icon={<IconAddPerson />}
+              onClick={handleOpenUserAdd}
+            ></NavBarButton>
+          </NavBarButtonGroup>
         }
       />
 

--- a/src/pages/congregation/manage_access/user_details/index.tsx
+++ b/src/pages/congregation/manage_access/user_details/index.tsx
@@ -7,6 +7,7 @@ import DeleteUser from '@features/congregation/app_access/user_details/delete_us
 import PageTitle from '@components/page_title';
 import UserMemberDetails from '@features/congregation/app_access/user_details';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const UserDetails = () => {
   const { t } = useAppTranslation();
@@ -42,14 +43,15 @@ const UserDetails = () => {
             fullnameOption
           )}
           buttons={
-            <NavBarButton
-              text={t('tr_delete')}
-              main
-              color="red"
-              icon={<IconDelete />}
-              disabled={deleteDisabled}
-              onClick={handleOpenDelete}
-            ></NavBarButton>
+            <NavBarButtonGroup>
+              <NavBarButton
+                text={t('tr_delete')}
+                color="red"
+                icon={<IconDelete />}
+                disabled={deleteDisabled}
+                onClick={handleOpenDelete}
+              ></NavBarButton>
+            </NavBarButtonGroup>
           }
         />
       )}

--- a/src/pages/congregation/settings/index.tsx
+++ b/src/pages/congregation/settings/index.tsx
@@ -15,6 +15,7 @@ import MeetingForms from '@features/congregation/settings/meeting_forms';
 import MinistrySettings from '@features/congregation/settings/ministry_settings';
 import PageTitle from '@components/page_title';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const CongregationSettings = () => {
   const { t } = useAppTranslation();
@@ -40,12 +41,13 @@ const CongregationSettings = () => {
         buttons={
           isAdmin &&
           !isGroup && (
-            <NavBarButton
-              main
-              text={t('tr_importExport')}
-              icon={<IconImportExport />}
-              onClick={handleOpenExchange}
-            ></NavBarButton>
+            <NavBarButtonGroup>
+              <NavBarButton
+                text={t('tr_importExport')}
+                icon={<IconImportExport />}
+                onClick={handleOpenExchange}
+              ></NavBarButton>
+            </NavBarButtonGroup>
           )
         }
       />

--- a/src/pages/meeting_materials/public_talks_list/index.tsx
+++ b/src/pages/meeting_materials/public_talks_list/index.tsx
@@ -5,6 +5,7 @@ import usePublicTalksList from './usePublicTalksList';
 import PageTitle from '@components/page_title';
 import PublicTalks from '@features/meeting_materials/public_talks';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const PublicTalksList = () => {
   const { t } = useAppTranslation();
@@ -24,18 +25,19 @@ const PublicTalksList = () => {
       <PageTitle
         title={t('tr_publicTalksList')}
         buttons={
-          <NavBarButton
-            main
-            text={currentView === 'list' ? t('tr_tableView') : t('tr_listView')}
-            icon={
-              currentView === 'list' ? (
-                <IconSpreadsheet height={22} width={22} />
-              ) : (
-                <IconListView height={22} width={22} />
-              )
-            }
-            onClick={handleToggleView}
-          ></NavBarButton>
+          <NavBarButtonGroup>
+            <NavBarButton
+              text={currentView === 'list' ? t('tr_tableView') : t('tr_listView')}
+              icon={
+                currentView === 'list' ? (
+                  <IconSpreadsheet height={22} width={22} />
+                ) : (
+                  <IconListView height={22} width={22} />
+                )
+              }
+              onClick={handleToggleView}
+            ></NavBarButton>
+          </NavBarButtonGroup>
         }
       />
 

--- a/src/pages/meetings/midweek/index.tsx
+++ b/src/pages/meetings/midweek/index.tsx
@@ -17,6 +17,7 @@ import SchedulePublish from '@features/meetings/schedule_publish';
 import ScheduleAutofillDialog from '@features/meetings/schedule_autofill';
 import WeekSelector from '@features/meetings/week_selector';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const MidweekMeeting = () => {
   const { t } = useAppTranslation();
@@ -84,7 +85,7 @@ const MidweekMeeting = () => {
         quickSettings={handleOpenQuickSettings}
         buttons={
           hasWeeks && (
-            <>
+            <NavBarButtonGroup>
               {openWeekView
                 ? desktopUp && (
                     <NavBarButton
@@ -118,7 +119,7 @@ const MidweekMeeting = () => {
                   onClick={handleOpenPublish}
                 ></NavBarButton>
               )}
-            </>
+            </NavBarButtonGroup>
           )
         }
       />

--- a/src/pages/meetings/midweek/index.tsx
+++ b/src/pages/meetings/midweek/index.tsx
@@ -17,6 +17,7 @@ import SchedulePublish from '@features/meetings/schedule_publish';
 import ScheduleAutofillDialog from '@features/meetings/schedule_autofill';
 import WeekSelector from '@features/meetings/week_selector';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const MidweekMeeting = () => {
   const { t } = useAppTranslation();
@@ -84,7 +85,7 @@ const MidweekMeeting = () => {
         quickSettings={handleOpenQuickSettings}
         buttons={
           hasWeeks && (
-            <>
+            <NavBarButtonGroup>
               {openWeekView
                 ? desktopUp && (
                     <NavBarButton
@@ -114,12 +115,11 @@ const MidweekMeeting = () => {
               {isConnected && (
                 <NavBarButton
                   text={t('tr_publish')}
-                  main
                   icon={<IconPublish />}
                   onClick={handleOpenPublish}
                 ></NavBarButton>
               )}
-            </>
+            </NavBarButtonGroup>
           )
         }
       />

--- a/src/pages/meetings/weekend/index.tsx
+++ b/src/pages/meetings/weekend/index.tsx
@@ -11,6 +11,7 @@ import WeekendEditor from '@features/meetings/weekend_editor';
 import WeekendExport from '@features/meetings/weekend_export';
 import WeekSelector from '@features/meetings/week_selector';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const WeekendMeeting = () => {
   const { t } = useAppTranslation();
@@ -75,7 +76,7 @@ const WeekendMeeting = () => {
         quickSettings={handleOpenQuickSettings}
         buttons={
           hasWeeks && (
-            <>
+            <NavBarButtonGroup>
               <NavBarButton
                 text={t('tr_export')}
                 icon={<IconPrint />}
@@ -90,12 +91,11 @@ const WeekendMeeting = () => {
               {isConnected && (
                 <NavBarButton
                   text={t('tr_publish')}
-                  main
                   icon={<IconPublish />}
                   onClick={handleOpenPublish}
                 ></NavBarButton>
               )}
-            </>
+            </NavBarButtonGroup>
           )
         }
       />

--- a/src/pages/meetings/weekend/index.tsx
+++ b/src/pages/meetings/weekend/index.tsx
@@ -11,6 +11,7 @@ import WeekendEditor from '@features/meetings/weekend_editor';
 import WeekendExport from '@features/meetings/weekend_export';
 import WeekSelector from '@features/meetings/week_selector';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const WeekendMeeting = () => {
   const { t } = useAppTranslation();
@@ -75,7 +76,7 @@ const WeekendMeeting = () => {
         quickSettings={handleOpenQuickSettings}
         buttons={
           hasWeeks && (
-            <>
+            <NavBarButtonGroup>
               <NavBarButton
                 text={t('tr_export')}
                 icon={<IconPrint />}
@@ -89,12 +90,11 @@ const WeekendMeeting = () => {
               {isConnected && (
                 <NavBarButton
                   text={t('tr_publish')}
-                  main
                   icon={<IconPublish />}
                   onClick={handleOpenPublish}
                 ></NavBarButton>
               )}
-            </>
+            </NavBarButtonGroup>
           )
         }
       />

--- a/src/pages/ministry/auxiliary_pioneer/index.tsx
+++ b/src/pages/ministry/auxiliary_pioneer/index.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
 import { useAppTranslation, useBreakpoints } from '@hooks/index';
 import PageTitle from '@components/page_title';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 import SubmitApplication from '@features/ministry/ap_application/submit_application';
 import UserApplicationForm from '@features/ministry/ap_application/main_form';
 
@@ -19,7 +20,7 @@ const AuxiliaryPioneer = () => {
     >
       <PageTitle
         title={t('tr_applicationAuxiliaryPioneer')}
-        buttons={<SubmitApplication />}
+        buttons={<NavBarButtonGroup><SubmitApplication /></NavBarButtonGroup>}
       />
 
       <UserApplicationForm />

--- a/src/pages/my_profile/index.tsx
+++ b/src/pages/my_profile/index.tsx
@@ -11,6 +11,7 @@ import UserProfileDetails from '@features/my_profile/user_profile_details';
 import UserSessions from '@features/my_profile/sessions';
 import UserTimeAway from '@features/my_profile/user_time_away';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const MyProfile = () => {
   const { t } = useAppTranslation();
@@ -38,13 +39,14 @@ const MyProfile = () => {
       <PageTitle
         title={t('tr_myProfile')}
         buttons={
-          <NavBarButton
-            text={t('tr_logOut')}
-            main
-            color="red"
-            icon={<IconLogout />}
-            onClick={handleOpenLogoutConfirm}
-          ></NavBarButton>
+          <NavBarButtonGroup>
+            <NavBarButton
+              text={t('tr_logOut')}
+              color="red"
+              icon={<IconLogout />}
+              onClick={handleOpenLogoutConfirm}
+            ></NavBarButton>
+          </NavBarButtonGroup>
         }
       />
 

--- a/src/pages/persons/all_persons/index.tsx
+++ b/src/pages/persons/all_persons/index.tsx
@@ -17,6 +17,7 @@ import PersonsList from '@features/persons/list';
 import PersonsFilter from '@features/persons/filter';
 import PersonsSearch from '@features/persons/search';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 import ImportExport from '@features/persons/import_export';
 
 const PersonsAll = () => {
@@ -48,20 +49,18 @@ const PersonsAll = () => {
         title={t('tr_personsAll')}
         buttons={
           isPersonEditor && (
-            <>
+            <NavBarButtonGroup>
               <NavBarButton
                 text={t('tr_importExport')}
-                main={false}
                 icon={<IconImportExport />}
                 onClick={handleOpenExchange}
               ></NavBarButton>
               <NavBarButton
                 text={t('tr_btnAdd')}
-                main
                 icon={<IconAddPerson />}
                 onClick={handlePersonAdd}
               ></NavBarButton>
-            </>
+            </NavBarButtonGroup>
           )
         }
       />

--- a/src/pages/persons/speakers_catalog/index.tsx
+++ b/src/pages/persons/speakers_catalog/index.tsx
@@ -10,6 +10,7 @@ import useSpeakersCatalog from './useSpeakersCatalog';
 import MyCongregation from '@features/persons/speakers_catalog/my_congregation';
 import OtherCongregations from '@features/persons/speakers_catalog/other_congregations';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const SpeakersCatalog = () => {
   const { t } = useAppTranslation();
@@ -32,16 +33,15 @@ const SpeakersCatalog = () => {
       <PageTitle
         title={t('tr_speakersCatalog')}
         buttons={
-          <>
-            {isPublicTalkCoordinator && (
+          isPublicTalkCoordinator && (
+            <NavBarButtonGroup>
               <NavBarButton
                 text={t('tr_btnAdd')}
-                main
                 icon={<IconAddCongregation color="var(--always-white)" />}
                 onClick={handleIsAddingOpen}
               ></NavBarButton>
-            )}
-          </>
+            </NavBarButtonGroup>
+          )
         }
       />
 

--- a/src/pages/reports/branch_office/useBranchOffice.tsx
+++ b/src/pages/reports/branch_office/useBranchOffice.tsx
@@ -10,6 +10,7 @@ import {
 import { branchFieldReportsState } from '@states/branch_field_service_reports';
 import { branchCongAnalysisState } from '@states/branch_cong_analysis';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const useBranchOffice = () => {
   const { t } = useAppTranslation();
@@ -75,7 +76,7 @@ const useBranchOffice = () => {
 
   const buttons = useMemo(() => {
     return (
-      <>
+      <NavBarButtonGroup>
         {!submitted && (
           <>
             <NavBarButton
@@ -86,7 +87,6 @@ const useBranchOffice = () => {
             ></NavBarButton>
             <NavBarButton
               text={t('tr_btnSubmitted')}
-              main
               disabled={!generated}
               icon={<IconCheckCircle />}
               onClick={handleOpenSubmit}
@@ -97,13 +97,12 @@ const useBranchOffice = () => {
         {submitted && (
           <NavBarButton
             text={t('tr_undoSubmission')}
-            main
             color="orange"
             icon={<IconUndo />}
             onClick={handleOpenWithdraw}
           ></NavBarButton>
         )}
-      </>
+      </NavBarButtonGroup>
     );
   }, [t, submitted, generated]);
 

--- a/src/pages/reports/field_service/index.tsx
+++ b/src/pages/reports/field_service/index.tsx
@@ -11,6 +11,7 @@ import PersonsList from '@features/reports/field_service/persons_list';
 import ReportDetails from '@features/reports/field_service/report_details';
 import SelectorStats from '@features/reports/field_service/selector_stats';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const FieldService = () => {
   const { t } = useAppTranslation();
@@ -33,16 +34,16 @@ const FieldService = () => {
       <PageTitle
         title={t('tr_fieldServiceReports')}
         buttons={
-          <>
-            {!isGroup && isSecretary && (
+          !isGroup &&
+          isSecretary && (
+            <NavBarButtonGroup>
               <NavBarButton
-                main
                 text={t('tr_createS1')}
                 icon={<IconPrepareReport />}
                 onClick={handleOpenBranchReport}
               ></NavBarButton>
-            )}
-          </>
+            </NavBarButtonGroup>
+          )
         }
       />
 

--- a/src/pages/reports/meeting_attendance/index.tsx
+++ b/src/pages/reports/meeting_attendance/index.tsx
@@ -9,6 +9,7 @@ import ExportS88 from '@features/reports/meeting_attendance/export_S88';
 import MonthlyHistory from '@features/reports/meeting_attendance/monthly_history';
 import MonthlyRecord from '@features/reports/meeting_attendance/monthly_record';
 import PageTitle from '@components/page_title';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 import QuickSettingsMeetingAttendanceRecord from '@features/reports/meeting_attendance/quick_settings';
 
 const MeetingAttendance = () => {
@@ -43,7 +44,14 @@ const MeetingAttendance = () => {
       <PageTitle
         title={t('tr_meetingAttendanceRecord')}
         quickSettings={isSecretary ? handleOpenQuickSettings : null}
-        buttons={!isGroup && isSecretary && <ExportS88 />}
+        buttons={
+          !isGroup &&
+          isSecretary && (
+            <NavBarButtonGroup>
+              <ExportS88 />
+            </NavBarButtonGroup>
+          )
+        }
       />
 
       <Box

--- a/src/pages/reports/publisher_records/index.tsx
+++ b/src/pages/reports/publisher_records/index.tsx
@@ -7,6 +7,7 @@ import PageTitle from '@components/page_title';
 import PublisherTabs from '@features/reports/publisher_records/publisher_tabs';
 import YearsStats from '@features/reports/publisher_records/years_stats';
 import NavBarButton from '@components/nav_bar_button';
+import NavBarButtonGroup from '@components/nav_bar_button_group';
 
 const PublisherRecords = () => {
   const { t } = useAppTranslation();
@@ -32,12 +33,13 @@ const PublisherRecords = () => {
       <PageTitle
         title={t('tr_publishersRecords')}
         buttons={
-          <NavBarButton
-            main
-            text={t('tr_exportS21')}
-            onClick={handleOpenExport}
-            icon={<IconExport />}
-          ></NavBarButton>
+          <NavBarButtonGroup>
+            <NavBarButton
+              text={t('tr_exportS21')}
+              onClick={handleOpenExport}
+              icon={<IconExport />}
+            ></NavBarButton>
+          </NavBarButtonGroup>
         }
       />
 


### PR DESCRIPTION
# Description

The rightmost button in the page header should always be visually prominent (filled). Previously, the `main` prop was hardcoded on specific buttons. When those buttons were conditionally hidden (e.g. no connection, insufficient permissions, test mode), no filled button remained.

This PR introduces a `NavBarButtonGroup` wrapper component that automatically promotes the **last visible child** to `main=true` at render time using `cloneElement`. All other children receive `main=false`.

### How it works

- `NavBarButtonGroup` recursively flattens Fragment children (handles `{cond && <><A/><B/></>}`)
- Promotes the last child unconditionally — the button's own `color` prop is preserved, so `color="red"` or `color="orange"` buttons stay red/orange when they are last
- Works with both direct `NavBarButton` elements and wrapper components (e.g. `ExportGroups`, `SubmitApplication`) that forward the `main` prop

### Changes

- **New component**: `src/components/nav_bar_button_group/index.tsx`
- **17 pages updated**: replaced `<>` fragments with `<NavBarButtonGroup>`, removed all hardcoded `main` props
- **5 wrapper components updated**: `ExportGroups`, `ExportUpcomingEvents`, `ExportS21`, `ExportS88`, `SubmitApplication` now accept and forward `main` as a prop — zero hardcoded `main` remains anywhere

### For future development

To add a red or orange button, just use `color="red"` or `color="orange"` on the `NavBarButton`. The group handles filled vs outlined automatically — no manual `main` needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules