### PR TITLE
fix(ui): improve assignment history divider color

### DIFF
--- a/src/features/meetings/assignments_history/index.tsx
+++ b/src/features/meetings/assignments_history/index.tsx
@@ -29,6 +29,7 @@ const AssignmentsHistory = ({
             '& .MuiTableCell-root': {
               padding: '8px',
               boxSizing: 'content-box',
+              borderColor: 'var(--accent-200)',
             },
           }}
         >


### PR DESCRIPTION
# Description

Fixes the divider colors in the assignments history to gracefully match the TableHead by utilizing `var(--accent-200)`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
