### PR TITLE
fix(pwa): display all the installation prompt screenshots

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -62,84 +62,90 @@
     {
       "src": "/img/screenshot/one_app_for_everyone_desktop.jpg",
       "sizes": "2919x2000",
-      "type": "image/png",
+      "type": "image/jpeg",
       "form_factor": "wide",
-      "label": "one_app_for_everyone_desktop"
-    },
-    {
-      "src": "/img/screenshot/collaborate_with_ease_desktop.jpg",
-      "sizes": "2919x2000",
-      "type": "image/png",
-      "form_factor": "wide",
-      "label": "collaborate_with_ease_desktop"
-    },
-    {
-      "src": "/img/screenshot/instant_reports_desktop.jpg",
-      "sizes": "2919x2000",
-      "type": "image/png",
-      "form_factor": "wide",
-      "label": "instant_reports_desktop"
-    },
-    {
-      "src": "/img/screenshot/light_and_dark_themes_desktop.jpg",
-      "sizes": "2919x2000",
-      "type": "image/png",
-      "form_factor": "wide",
-      "label": "light_and_dark_themes_desktop"
-    },
-    {
-      "src": "/img/screenshot/truly_multi_platform_desktop.jpg",
-      "sizes": "2919x2000",
-      "type": "image/png",
-      "form_factor": "wide",
-      "label": "truly_multi_platform_desktop"
-    },
-    {
-      "src": "/img/screenshot/way_less_stress_desktop.jpg",
-      "sizes": "2919x2000",
-      "type": "image/png",
-      "form_factor": "wide",
-      "label": "way_less_stress_desktop"
+      "label": "One App For Everyone"
     },
     {
       "src": "/img/screenshot/one_app_for_everyone_mobile.jpg",
       "sizes": "1125x2000",
-      "type": "image/png",
+      "type": "image/jpeg",
       "form_factor": "narrow",
-      "label": "one_app_for_everyone_mobile"
+      "label": "One App For Everyone"
+    },
+    {
+      "src": "/img/screenshot/collaborate_with_ease_desktop.jpg",
+      "sizes": "2919x2000",
+      "type": "image/jpeg",
+      "form_factor": "wide",
+      "label": "Collaborate With Ease"
     },
     {
       "src": "/img/screenshot/collaborate_with_ease_mobile.jpg",
       "sizes": "1125x2000",
-      "type": "image/png",
+      "type": "image/jpeg",
       "form_factor": "narrow",
-      "label": "collaborate_with_ease_mobile"
+      "label": "Collaborate With Ease"
+    },
+    {
+      "src": "/img/screenshot/instant_reports_desktop.jpg",
+      "sizes": "2919x2000",
+      "type": "image/jpeg",
+      "form_factor": "wide",
+      "label": "Instant Reports"
     },
     {
       "src": "/img/screenshot/instant_reports_mobile.jpg",
       "sizes": "1125x2000",
-      "type": "image/png",
+      "type": "image/jpeg",
       "form_factor": "narrow",
-      "label": "instant_reports_mobile"
+      "label": "Instant Reports"
+    },
+    {
+      "src": "/img/screenshot/light_and_dark_themes_desktop.jpg",
+      "sizes": "2919x2000",
+      "type": "image/jpeg",
+      "form_factor": "wide",
+      "label": "Light And Dark Themes"
     },
     {
       "src": "/img/screenshot/light_and_dark_themes_mobile.jpg",
       "sizes": "1125x2000",
-      "type": "image/png",
+      "type": "image/jpeg",
       "form_factor": "narrow",
-      "label": "light_and_dark_themes_mobile"
+      "label": "Light And Dark Themes"
+    },
+    {
+      "src": "/img/screenshot/truly_multi_platform_desktop.jpg",
+      "sizes": "2919x2000",
+      "type": "image/jpeg",
+      "form_factor": "wide",
+      "label": "Truly Multi Platform"
     },
     {
       "src": "/img/screenshot/truly_multi_platform_mobile.jpg",
       "sizes": "1125x2000",
-      "type": "image/png",
+      "type": "image/jpeg",
       "form_factor": "narrow",
-      "label": "truly_multi_platform_mobile"
+      "label": "Truly Multi Platform"
+    },
+    {
+      "src": "/img/screenshot/way_less_stress_desktop.jpg",
+      "sizes": "2919x2000",
+      "type": "image/jpeg",
+      "form_factor": "wide",
+      "label": "Way Less Stress"
     }
   ],
   "url_handlers": [
-    { "origin": "https://cpe-web.sws2apps.com" },
-    { "origin": "https://cpe-sws.web.app" },
-    { "origin": "https://cpe-sws.firebaseapp.com" }
+    {
+      "origin": "https://cpe-web.sws2apps.com"
+    },
+    {
+      "origin": "https://cpe-sws.web.app"
+    },
+    {
+      "origin": "https://cpe-sws.firebaseapp.com"
+    }
   ]
 }


### PR DESCRIPTION
# Description

This PR fixes two significant issues preventing all screenshots from showing during PWA installation, especially on mobile devices where often only 2 were shown.

1. **MIME Type Fix:** The `manifest.webmanifest` listed screenshot types as `image/png`, but the actual files in `/public/img/screenshot` are JPEGs. Strict parsers reject files with mismatched MIME types. Updated the manifest to use `image/jpeg`.
2. **Parser Array Truncation Fix:** Chromium PWA parsers typically enforce an absolute limit of 8 total parsed screenshots per manifest. Because the previous array was sorted with all 6 desktop screenshots first, followed by the mobile screenshots, the parser hit the 8-item cutoff and only processed 2 mobile screenshots. By interleaving them (desktop, mobile, desktop, mobile), the array parser will equally distribute the parsed screenshots (4 desktop, 4 mobile) even if truncated.
3. **Readable Labels:** Updated the screenshot labels to use clean, human-readable titles instead of file names with underscores.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
