### PR TITLE
feat(reports): add elder school credit hours preset

### DIFF
--- a/src/features/ministry/report/hours_credit_presets/useHoursCreditPresets.tsx
+++ b/src/features/ministry/report/hours_credit_presets/useHoursCreditPresets.tsx
@@ -5,13 +5,17 @@ import {
   IconLanguageCourse,
   IconSchool,
   IconSchoolForEvangelizers,
+  IconTalk,
 } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
+import useCurrentUser from '@hooks/useCurrentUser';
 
 const useHoursCreditPresets = () => {
   const location = useLocation();
 
   const { t } = useAppTranslation();
+
+  const { isElder } = useCurrentUser();
 
   const [presetsOpen, setPresetsOpen] = useState(false);
 
@@ -22,6 +26,17 @@ const useHoursCreditPresets = () => {
         name: t('tr_pioneerSchool'),
         value: 30,
       },
+    ];
+
+    if (isElder) {
+      list.push({
+        icon: <IconTalk color="var(--black)" />,
+        name: t('tr_elderSchool'),
+        value: 30,
+      });
+    }
+
+    list.push(
       {
         icon: <IconSchoolForEvangelizers color="var(--black)" />,
         name: t('tr_SKE'),
@@ -31,8 +46,8 @@ const useHoursCreditPresets = () => {
         icon: <IconLanguageCourse color="var(--black)" />,
         name: t('tr_languageCourse'),
         value: 25,
-      },
-    ];
+      }
+    );
 
     if (location.pathname === '/ministry-report') {
       list.push({
@@ -43,7 +58,7 @@ const useHoursCreditPresets = () => {
     }
 
     return list;
-  }, [t, location.pathname]);
+  }, [t, location.pathname, isElder]);
 
   const handleTogglePresets = () => setPresetsOpen((prev) => !prev);
 

--- a/src/locales/en/ministry.json
+++ b/src/locales/en/ministry.json
@@ -6,6 +6,7 @@
   "tr_addNewStudy": "Add new Bible study",
   "tr_editBibleStudy": "Edit Bible study",
   "tr_pioneerSchool": "Pioneer school",
+  "tr_elderSchool": "School for congregation elders",
   "tr_ministryTimeHours": "{{ ministryTime }} hours",
   "tr_SKE": "School for Kingdom Evangelizers",
   "tr_languageCourse": "Language class",


### PR DESCRIPTION
# Description

Add a new credit hours preset called **School for congregation elders** (30 hours) to the ministry credit hours preset list.

This preset:
- Uses the existing talk icon (`IconTalk`) to match the existing visual style
- Appears **second in the list**, right after Pioneer school
- Is **only visible to elders** (checked via `useCurrentUser`'s `isElder` flag)
- Since the credit hours window is already gated to pioneers, this preset is effectively shown only to elders who are also pioneers
- Applies consistently across all 3 places where the preset component is used (ministry time dialog, S-4 form, publisher records credit field) — all share the same `useHoursCreditPresets` hook

Changes:
- `src/features/ministry/report/hours_credit_presets/useHoursCreditPresets.tsx`: added elder school preset with conditional `isElder` check
- `src/locales/en/ministry.json`: added `tr_elderSchool` translation key

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules