### PR TITLE
fix(sources): resolve AYF type misclassification for compound EPUB labels (#5059)

### DIFF
--- a/src/services/app/sources.ts
+++ b/src/services/app/sources.ts
@@ -46,7 +46,7 @@ export const sourcesImportJW = async (dataJw) => {
 
 const normalizeAYFLabel = (label: string) =>
   label
-    .replaceAll('\u200B', '')
+    .replace(/(?:\u200B|\u200C|\u200D|\u2060|\uFEFF)/g, '')
     .replace(/[^\p{L}\p{N}\s]/gu, ' ')
     .replace(/\s+/g, ' ')
     .toLowerCase()
@@ -136,8 +136,9 @@ const sourcesFormatAndSaveData = async (data: SourceWeekIncomingType[]) => {
   if (assTypeList.length === 0) {
     logger.warn(
       'sources',
-      'AYF assignment type list is empty — type inference will default to MM_Discussion for all parts'
+      'AYF assignment type list is empty — aborting import to prevent assignment data corruption'
     );
+    return;
   }
 
   const ayfLookup = buildAYFLookup(assTypeList);

--- a/src/services/app/sources.ts
+++ b/src/services/app/sources.ts
@@ -8,6 +8,7 @@ import {
   SourceWeekIncomingType,
   SourceWeekType,
 } from '@definition/sources';
+import { AssignmentAYFOnlyType, AssignmentCode } from '@definition/assignment';
 import { assignmentTypeAYFOnlyState } from '@states/assignment';
 import { dbSourcesSave } from '@services/dexie/sources';
 import { dbSchedCheck } from '@services/dexie/schedules';
@@ -21,6 +22,7 @@ import {
 } from '@states/settings';
 import { addWeeks, formatDate, getWeekDate } from '@utils/date';
 import { STORAGE_KEY } from '@constants/index';
+import logger from '@services/logger';
 
 export const sourcesImportEPUB = async (fileEPUB) => {
   const data = await loadPub(fileEPUB);
@@ -42,6 +44,76 @@ export const sourcesImportJW = async (dataJw) => {
   }
 };
 
+const normalizeAYFLabel = (label: string) =>
+  label
+    .replaceAll('\u200B', '')
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+    .trim();
+
+type NormalizedAYFType = {
+  normalized: string;
+  value: number;
+};
+
+const buildAYFLookup = (assTypeList: AssignmentAYFOnlyType[]) => {
+  const exactMap = new Map<string, number>();
+  for (const type of assTypeList) {
+    const key = normalizeAYFLabel(type.label);
+    if (key.length > 0) {
+      exactMap.set(key, type.value);
+    }
+  }
+
+  const prefixList: NormalizedAYFType[] = assTypeList
+    .map((type) => ({
+      normalized: normalizeAYFLabel(type.label),
+      value: type.value,
+    }))
+    .filter((entry) => entry.normalized.length > 0)
+    .sort((a, b) => b.normalized.length - a.normalized.length);
+
+  return { exactMap, prefixList };
+};
+
+const inferAYFTypeFromLabel = (
+  rawLabel: string | undefined | null,
+  lookup: ReturnType<typeof buildAYFLookup>
+): number => {
+  if (!rawLabel?.trim()) {
+    logger.warn(
+      'sources',
+      'AYF type label is empty or missing, falling back to MM_Discussion'
+    );
+    return AssignmentCode.MM_Discussion;
+  }
+
+  const normalizedInput = normalizeAYFLabel(rawLabel);
+
+  if (!normalizedInput) {
+    logger.warn(
+      'sources',
+      `AYF type label reduced to empty after normalization, falling back to MM_Discussion: "${rawLabel.slice(0, 100)}"`
+    );
+    return AssignmentCode.MM_Discussion;
+  }
+
+  const exactValue = lookup.exactMap.get(normalizedInput);
+  if (exactValue !== undefined) return exactValue;
+
+  const prefixMatch = lookup.prefixList.find((type) =>
+    normalizedInput.startsWith(type.normalized)
+  );
+  if (prefixMatch) return prefixMatch.value;
+
+  logger.warn(
+    'sources',
+    `AYF type label not recognized, falling back to MM_Discussion: "${rawLabel.slice(0, 100)}"`
+  );
+  return AssignmentCode.MM_Discussion;
+};
+
 const remapAssignmentType = (week: string, type: number) => {
   if (week < '2024/01/01') {
     return type;
@@ -60,6 +132,15 @@ const remapAssignmentType = (week: string, type: number) => {
 const sourcesFormatAndSaveData = async (data: SourceWeekIncomingType[]) => {
   const source_lang = store.get(JWLangState);
   const assTypeList = store.get(assignmentTypeAYFOnlyState);
+
+  if (assTypeList.length === 0) {
+    logger.warn(
+      'sources',
+      'AYF assignment type list is empty — type inference will default to MM_Discussion for all parts'
+    );
+  }
+
+  const ayfLookup = buildAYFLookup(assTypeList);
 
   for await (const src of data) {
     const obj = {} as SourceWeekType;
@@ -105,12 +186,7 @@ const sourcesFormatAndSaveData = async (data: SourceWeekIncomingType[]) => {
         const cnAYF = src.mwb_ayf_count;
         obj.midweek_meeting.ayf_count = { [source_lang]: src.mwb_ayf_count };
 
-        assType =
-          assTypeList.find(
-            (type) =>
-              type.label.replace(/\u200B/g, '') ===
-              src.mwb_ayf_part1_type.replace(/\u200B/g, '')
-          )?.value || 127;
+        assType = inferAYFTypeFromLabel(src.mwb_ayf_part1_type, ayfLookup);
 
         assType = remapAssignmentType(obj.weekOf, assType);
 
@@ -122,12 +198,7 @@ const sourcesFormatAndSaveData = async (data: SourceWeekIncomingType[]) => {
         };
 
         if (cnAYF > 1) {
-          assType =
-            assTypeList.find(
-              (type) =>
-                type.label.replace(/\u200B/g, '') ===
-                src.mwb_ayf_part2_type.replace(/\u200B/g, '')
-            )?.value || 127;
+          assType = inferAYFTypeFromLabel(src.mwb_ayf_part2_type, ayfLookup);
 
           assType = remapAssignmentType(obj.weekOf, assType);
 
@@ -140,12 +211,7 @@ const sourcesFormatAndSaveData = async (data: SourceWeekIncomingType[]) => {
         }
 
         if (cnAYF > 2) {
-          assType =
-            assTypeList.find(
-              (type) =>
-                type.label.replace(/\u200B/g, '') ===
-                src.mwb_ayf_part3_type.replace(/\u200B/g, '')
-            )?.value || 127;
+          assType = inferAYFTypeFromLabel(src.mwb_ayf_part3_type, ayfLookup);
 
           assType = remapAssignmentType(obj.weekOf, assType);
 
@@ -158,12 +224,7 @@ const sourcesFormatAndSaveData = async (data: SourceWeekIncomingType[]) => {
         }
 
         if (cnAYF > 3) {
-          assType =
-            assTypeList.find(
-              (type) =>
-                type.label.replace(/\u200B/g, '') ===
-                src.mwb_ayf_part4_type.replace(/\u200B/g, '')
-            )?.value || 127;
+          assType = inferAYFTypeFromLabel(src.mwb_ayf_part4_type, ayfLookup);
 
           assType = remapAssignmentType(obj.weekOf, assType);
 


### PR DESCRIPTION
Replaces PR #5203 from a dedicated branch. Fixes #5059

# Description

When importing meeting workbook data via EPUB file, the `meeting-schedules-parser` library returns compound type labels for certain Apply Yourself to the Field Ministry parts, e.g.:

```
Making Disciples (5 min.) lff lesson 18 summary, review, and goal
```

The previous exact-match lookup against the stored assignment type list failed to match these compound strings and silently fell back to `MM_Discussion` (type 127). This caused the assistant assignment field to be hidden in the midweek meeting scheduling editor for affected weeks, making it impossible to assign a second person to those parts.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules