### PR TITLE
fix(ui): prevent width shift in filter chip and button group on selection

### DIFF
--- a/src/components/button_group/index.tsx
+++ b/src/components/button_group/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Button, ButtonGroup as MuiButtonGroup } from '@mui/material';
 import { ButtonGroupType } from './index.types';
 
@@ -21,16 +22,45 @@ const ButtonGroup = ({ buttons }: ButtonGroupType) => {
         },
       }}
     >
-      {buttons.map((button) => (
-        <Button
-          key={button.children.toString()}
-          {...button}
-          className={`${button.className} ${button.className === 'active' ? 'h4' : 'body-regular'}`}
-          sx={{ padding: '0 20px' }}
-        />
-      ))}
+      {buttons.map((button, index) => {
+        const labelText = React.Children.toArray(button.children)
+          .map((c) => (typeof c === 'string' || typeof c === 'number' ? String(c) : ''))
+          .join('');
+        return (
+          <Button
+            key={`button-${index}`}
+            {...button}
+            className={`${button.className ?? ''} ${(button.className ?? '') === 'active' ? 'h4' : 'body-regular'}`}
+            data-text={labelText}
+            sx={{
+              padding: '0 20px',
+              display: 'inline-flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              alignItems: 'center',
+              '&::after': {
+                content: 'attr(data-text)',
+                fontWeight: 500,
+                fontSize: '16px',
+                letterSpacing: '0px',
+                height: 0,
+                visibility: 'hidden',
+                overflow: 'hidden',
+                pointerEvents: 'none',
+                userSelect: 'none',
+                display: 'block',
+                '@media (max-width: 768px)': {
+                  fontSize: '15px',
+                  letterSpacing: '-0.3px',
+                },
+              },
+            }}
+          />
+        );
+      })}
     </MuiButtonGroup>
   );
 };
 
 export default ButtonGroup;
+

--- a/src/components/filter_chip/index.tsx
+++ b/src/components/filter_chip/index.tsx
@@ -3,6 +3,9 @@ import { Button } from '@mui/material';
 /**
  * Component representing a custom filter chip.
  *
+ * Uses an invisible bold `::after` pseudo-element to always reserve the
+ * semibold text width, preventing layout shift when toggling selection.
+ *
  * @param {{
  *   label: string;
  *   onClick?: VoidFunction;
@@ -26,6 +29,7 @@ const CustomFilterChip = ({
     <Button
       disableRipple
       onClick={onClick}
+      data-text={label}
       className={selected ? 'body-small-semibold' : 'body-small-regular'}
       sx={{
         fontFeatureSettings: '"cv05"',
@@ -37,6 +41,28 @@ const CustomFilterChip = ({
           : '1px solid var(--accent-400)',
         backgroundColor: selected ? 'var(--accent-200)' : 'unset',
         minHeight: '34px',
+        display: 'inline-flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        '&::after': {
+          content: 'attr(data-text)',
+          fontWeight: 520,
+          fontSize: '14px',
+          letterSpacing: '0px',
+          fontFeatureSettings: '"cv05"',
+          height: 0,
+          visibility: 'hidden',
+          overflow: 'hidden',
+          pointerEvents: 'none',
+          userSelect: 'none',
+          display: 'block',
+          '@media (max-width: 767px)': {
+            fontWeight: 450,
+            fontSize: '13px',
+            letterSpacing: '0.065px',
+          },
+        },
         '&:hover': {
           color: selected ? 'var(--accent-dark)' : 'var(--accent-400)',
           backgroundColor: selected ? 'var(--accent-200)' : 'var(--accent-150)',


### PR DESCRIPTION
## Description

Fixes a layout shift bug where `CustomFilterChip` and `ButtonGroup` buttons visually jump in width when toggling between selected and unselected states, because the two states use different font weights.

**Root cause:** Font-weight changes between `body-small-regular` (400) and `body-small-semibold` (520) cause the rendered text to widen/narrow, shifting surrounding elements.

**Fix:** An invisible bold `::after` pseudo-element always occupies the maximum (semibold/active) text width via `content: attr(data-text)`, so the element's layout size never changes regardless of selection state. No JavaScript measurement or fixed widths needed — works for any label length.

### Components fixed
- **`CustomFilterChip`** — filter chips on the Persons page and other list filters
- **`ButtonGroup`** — segmented button group used in various views

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules