### PR TITLE
fix(schedule): handle undefined weekend_meeting when publishing

### DIFF
--- a/src/features/meetings/schedule_publish/useSchedulePublish.tsx
+++ b/src/features/meetings/schedule_publish/useSchedulePublish.tsx
@@ -354,7 +354,9 @@ const useSchedulePublish = ({ type, onClose }: SchedulePublishProps) => {
     const publish = weekend.outgoing_talks_schedule_public.value;
 
     const result = schedules.map((schedule) => {
-      if (!publish) delete schedule.weekend_meeting.outgoing_talks;
+      if (!publish && schedule.weekend_meeting) {
+        delete schedule.weekend_meeting.outgoing_talks;
+      }
 
       return schedule;
     });


### PR DESCRIPTION
# Description

This PR fixes a bug where attempting to share/publish the weekend meeting crashes the application with a "Cannot convert undefined or null to object" error.

The bug occurred when `handleFilterOutgoingTalks` attempted to delete the `outgoing_talks` property from `schedule.weekend_meeting`. If a schedule record had an incomplete or missing `weekend_meeting` property (which happens for some older records or incomplete weeks), `delete schedule.weekend_meeting.outgoing_talks` evaluated to `delete undefined.outgoing_talks`, causing the JS engine to crash. 

Added an existence check `if (!publish && schedule.weekend_meeting)` to safeguard the operation.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
