### PR TITLE
feat(meetings): implement family filtering for manual assistant assignments

### DIFF
--- a/src/features/meetings/person_selector/student_selector/index.tsx
+++ b/src/features/meetings/person_selector/student_selector/index.tsx
@@ -1,7 +1,7 @@
 import { Box, FormControlLabel, Popper, RadioGroup } from '@mui/material';
 import { STUDENT_ASSIGNMENT } from '@constants/index';
 import { PersonOptionsType, PersonSelectorType } from '../index.types';
-import { Gender, StudentIconType } from './index.types';
+import { StudentIconType } from './index.types';
 import {
   IconAssignmetHistory,
   IconClose,

--- a/src/features/meetings/person_selector/student_selector/index.tsx
+++ b/src/features/meetings/person_selector/student_selector/index.tsx
@@ -218,16 +218,15 @@ const StudentSelector = (props: PersonSelectorType) => {
                           control={<Radio />}
                           label={
                             <Typography>
-                              {mainStudentGender === 'male'
-                                ? t('tr_male')
-                                : t('tr_female')}
+                              {t(
+                                mainStudentGender === 'male'
+                                  ? 'tr_male'
+                                  : 'tr_female'
+                              )}
                             </Typography>
                           }
                           onClick={(e) =>
-                            handleGenderChange(
-                              e,
-                              mainStudentGender as Gender
-                            )
+                            handleGenderChange(e, mainStudentGender)
                           }
                         />
                         {showFamilyFilter && (

--- a/src/features/meetings/person_selector/student_selector/index.tsx
+++ b/src/features/meetings/person_selector/student_selector/index.tsx
@@ -1,6 +1,7 @@
 import { Box, FormControlLabel, Popper, RadioGroup } from '@mui/material';
 import { STUDENT_ASSIGNMENT } from '@constants/index';
 import { PersonOptionsType, PersonSelectorType } from '../index.types';
+import { Gender, StudentIconType } from './index.types';
 import {
   IconAssignmetHistory,
   IconClose,
@@ -8,7 +9,6 @@ import {
   IconMale,
   IconPersonPlaceholder,
 } from '@components/icons';
-import { StudentIconType } from './index.types';
 import { useAppTranslation, useBreakpoints } from '@hooks/index';
 import useStudentSelector from './useStudentSelector';
 import AssignmentsHistoryDialog from '@features/meetings/assignments_history_dialog';
@@ -53,6 +53,8 @@ const StudentSelector = (props: PersonSelectorType) => {
     handleToggleGroup,
     showHeader,
     showGroupToggle,
+    mainStudentGender,
+    showFamilyFilter,
   } = useStudentSelector(props);
 
   return (
@@ -192,18 +194,56 @@ const StudentSelector = (props: PersonSelectorType) => {
               >
                 {showGenderSelector && (
                   <>
-                    <FormControlLabel
-                      value="male"
-                      control={<Radio />}
-                      label={<Typography>{t('tr_male')}</Typography>}
-                      onClick={(e) => handleGenderChange(e, 'male')}
-                    />
-                    <FormControlLabel
-                      value="female"
-                      control={<Radio />}
-                      label={<Typography>{t('tr_female')}</Typography>}
-                      onClick={(e) => handleGenderChange(e, 'female')}
-                    />
+                    {!isAssistant && (
+                      <>
+                        <FormControlLabel
+                          value="male"
+                          control={<Radio />}
+                          label={<Typography>{t('tr_male')}</Typography>}
+                          onClick={(e) => handleGenderChange(e, 'male')}
+                        />
+                        <FormControlLabel
+                          value="female"
+                          control={<Radio />}
+                          label={<Typography>{t('tr_female')}</Typography>}
+                          onClick={(e) => handleGenderChange(e, 'female')}
+                        />
+                      </>
+                    )}
+
+                    {isAssistant && mainStudentGender && (
+                      <>
+                        <FormControlLabel
+                          value={mainStudentGender}
+                          control={<Radio />}
+                          label={
+                            <Typography>
+                              {mainStudentGender === 'male'
+                                ? t('tr_male')
+                                : t('tr_female')}
+                            </Typography>
+                          }
+                          onClick={(e) =>
+                            handleGenderChange(
+                              e,
+                              mainStudentGender as Gender
+                            )
+                          }
+                        />
+                        {showFamilyFilter && (
+                          <FormControlLabel
+                            value="family"
+                            control={<Radio />}
+                            label={
+                              <Typography>{t('tr_family')}</Typography>
+                            }
+                            onClick={(e) =>
+                              handleGenderChange(e, 'family')
+                            }
+                          />
+                        )}
+                      </>
+                    )}
                   </>
                 )}
 

--- a/src/features/meetings/person_selector/student_selector/index.types.ts
+++ b/src/features/meetings/person_selector/student_selector/index.types.ts
@@ -6,4 +6,4 @@ export type StudentIconType = {
   value?: PersonOptionsType;
 };
 
-export type Gender = 'male' | 'female';
+export type Gender = 'male' | 'female' | 'family';

--- a/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
+++ b/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
@@ -441,12 +441,10 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
 
       if (isFamilyMember && !sameGender) {
         setGender('family');
-      } else {
-        const assignedGender = personAssigned.person_data.male.value
-          ? 'male'
-          : 'female';
-        setGender(assignedGender);
+        return;
       }
+
+      setGender(personAssigned.person_data.male.value ? 'male' : 'female');
       return;
     }
 

--- a/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
+++ b/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
@@ -463,6 +463,12 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
     }
   }, [personAssigned, isAssistant, mainStudentAssigned, familyMemberUIDs]);
 
+  const mainStudentGender = mainStudentAssigned
+    ? mainStudentAssigned.person_data.male.value
+      ? 'male'
+      : 'female'
+    : null;
+
   return {
     options,
     showGenderSelector,
@@ -480,11 +486,7 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
     helperText,
     handleToggleGroup,
     groupChecked,
-    mainStudentGender: mainStudentAssigned
-      ? mainStudentAssigned.person_data.male.value
-        ? 'male'
-        : 'female'
-      : null,
+    mainStudentGender,
     showFamilyFilter: familyMemberUIDs.size > 0,
   };
 };

--- a/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
+++ b/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
@@ -186,31 +186,27 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
         );
       }
 
-      if (isAssistant) {
-        if (!mainStudentAssigned) return false;
+      if (!mainStudentAssigned) return false;
 
-        const hasAssistantRole = activeAssignments.some((a) =>
-          ASSISTANT_ASSIGNMENT.includes(a)
-        );
+      const hasAssistantRole = activeAssignments.some((a) =>
+        ASSISTANT_ASSIGNMENT.includes(a)
+      );
 
-        if (!hasAssistantRole) return false;
+      if (!hasAssistantRole) return false;
 
-        if (record.person_uid === mainStudentAssigned.person_uid) return false;
+      if (record.person_uid === mainStudentAssigned.person_uid) return false;
 
-        if (gender === 'family') {
-          return familyMemberUIDs.has(record.person_uid);
-        }
-
-        const isMale = mainStudentAssigned.person_data.male.value;
-        const isFemale = mainStudentAssigned.person_data.female.value;
-
-        return (
-          record.person_data.male.value === isMale &&
-          record.person_data.female.value === isFemale
-        );
+      if (gender === 'family') {
+        return familyMemberUIDs.has(record.person_uid);
       }
 
-      return false;
+      const isMale = mainStudentAssigned.person_data.male.value;
+      const isFemale = mainStudentAssigned.person_data.female.value;
+
+      return (
+        record.person_data.male.value === isMale &&
+        record.person_data.female.value === isFemale
+      );
     });
 
     const newPersons: PersonOptionsType[] =

--- a/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
+++ b/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
@@ -456,18 +456,15 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
 
     if (personAssigned?.person_data.female.value) {
       setGender('female');
-    }
-
-    if (personAssigned?.person_data.male.value) {
+    } else if (personAssigned?.person_data.male.value) {
       setGender('male');
     }
   }, [personAssigned, isAssistant, mainStudentAssigned, familyMemberUIDs]);
 
-  const mainStudentGender = mainStudentAssigned
-    ? mainStudentAssigned.person_data.male.value
-      ? 'male'
-      : 'female'
-    : null;
+  let mainStudentGender: 'male' | 'female' | null = null;
+  if (mainStudentAssigned) {
+    mainStudentGender = mainStudentAssigned.person_data.male.value ? 'male' : 'female';
+  }
 
   return {
     options,

--- a/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
+++ b/src/features/meetings/person_selector/student_selector/useStudentSelector.tsx
@@ -1,9 +1,10 @@
-import { MouseEvent, useEffect, useMemo, useState } from 'react';
+import { MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router';
 import { useAtomValue } from 'jotai';
 import { IconError } from '@components/icons';
 import { PersonOptionsType, PersonSelectorType } from '../index.types';
 import { personsByViewState } from '@states/persons';
+import { PersonType } from '@definition/person';
 import {
   displayNameMeetingsEnableState,
   fullnameOptionState,
@@ -34,7 +35,7 @@ import { fieldGroupsState } from '@states/field_service_groups';
 import { displaySnackNotification } from '@services/states/app';
 import { getMessageByCode } from '@services/i18n/translation';
 import { formatDate } from '@utils/date';
-import { personIsAway } from '@services/app/persons';
+import { personGetFamilyMemberUIDs, personIsAway } from '@services/app/persons';
 
 const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
   const location = useLocation();
@@ -93,83 +94,33 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
     return assignedFSG.length > 0;
   }, [congAssignFSG, assignment, schedule, classCount, dataView, assignedFSG]);
 
-  const options = useMemo(() => {
-    const filteredPersons = persons.filter((record) => {
-      if (showGroupToggle && groupChecked) {
-        const findInGroup = serviceGroups.find((g) =>
-          g.group_data.members.some((m) => m.person_uid === record.person_uid)
-        );
+  const mainStudentAssigned = useMemo(() => {
+    if (!isAssistant || week.length === 0) return null;
 
-        if (!findInGroup) return false;
+    const pathMainStudent =
+      ASSIGNMENT_PATH[assignment.replace('Assistant', 'Student')];
 
-        if (findInGroup.group_id !== assignedFSG) return false;
-      }
+    if (!pathMainStudent) return null;
 
-      const activeAssignments =
-        record.person_data.assignments.find((a) => a.type === dataView)
-          ?.values ?? [];
+    const assigned = schedulesGetData(
+      schedule,
+      pathMainStudent,
+      dataView
+    ) as AssignmentCongregation;
 
-      if (!isAssistant) {
-        return (
-          activeAssignments.includes(type) &&
-          ((gender === 'male' && record.person_data.male.value) ||
-            (gender === 'female' && record.person_data.female.value))
-        );
-      }
+    return (
+      persons.find((record) => record.person_uid === assigned?.value) ?? null
+    );
+  }, [isAssistant, week, assignment, schedule, dataView, persons]);
 
-      if (isAssistant) {
-        const pathMainStudent =
-          ASSIGNMENT_PATH[assignment.replace('Assistant', 'Student')];
+  const familyMemberUIDs = useMemo(() => {
+    if (!mainStudentAssigned) return new Set<string>();
 
-        const dataSchedule = schedulesGetData(schedule, pathMainStudent);
+    return personGetFamilyMemberUIDs(persons, mainStudentAssigned.person_uid);
+  }, [mainStudentAssigned, persons]);
 
-        let assigned: AssignmentCongregation;
-
-        if (Array.isArray(dataSchedule)) {
-          assigned = dataSchedule.find((record) => record.type === dataView);
-        } else {
-          assigned = dataSchedule;
-        }
-
-        const mainStudent = persons.find(
-          (record) => record.person_uid === assigned?.value
-        );
-
-        if (mainStudent) {
-          const assignment = activeAssignments.some((assignment) =>
-            ASSISTANT_ASSIGNMENT.includes(assignment)
-          );
-
-          const isMale = mainStudent.person_data.male.value;
-          const isFemale = mainStudent.person_data.female.value;
-
-          const isFamilyMembers =
-            mainStudent.person_data.family_members?.members.includes(
-              record.person_uid
-            );
-
-          const isFamilyHead =
-            record.person_data.family_members?.members.includes(
-              mainStudent.person_uid
-            );
-
-          const isFamily = isFamilyMembers || isFamilyHead;
-
-          return (
-            assignment &&
-            (isFamily ||
-              (record.person_data.male.value === isMale &&
-                record.person_data.female.value === isFemale))
-          );
-        }
-
-        return false;
-      }
-
-      return false;
-    });
-
-    const newPersons: PersonOptionsType[] = filteredPersons.map((record) => {
+  const buildPersonOption = useCallback(
+    (record: PersonType): PersonOptionsType => {
       const lastAssignment = assignmentsHistory.find(
         (item) => item.assignment.person === record.person_uid
       );
@@ -207,7 +158,63 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
           fullnameOption
         ),
       };
+    },
+    [assignmentsHistory, shortDateFormat, t, displayNameEnabled, fullnameOption]
+  );
+
+  const options = useMemo(() => {
+    const filteredPersons = persons.filter((record) => {
+      if (showGroupToggle && groupChecked) {
+        const findInGroup = serviceGroups.find((g) =>
+          g.group_data.members.some((m) => m.person_uid === record.person_uid)
+        );
+
+        if (!findInGroup) return false;
+
+        if (findInGroup.group_id !== assignedFSG) return false;
+      }
+
+      const activeAssignments =
+        record.person_data.assignments.find((a) => a.type === dataView)
+          ?.values ?? [];
+
+      if (!isAssistant) {
+        return (
+          activeAssignments.includes(type) &&
+          ((gender === 'male' && record.person_data.male.value) ||
+            (gender === 'female' && record.person_data.female.value))
+        );
+      }
+
+      if (isAssistant) {
+        if (!mainStudentAssigned) return false;
+
+        const hasAssistantRole = activeAssignments.some((a) =>
+          ASSISTANT_ASSIGNMENT.includes(a)
+        );
+
+        if (!hasAssistantRole) return false;
+
+        if (record.person_uid === mainStudentAssigned.person_uid) return false;
+
+        if (gender === 'family') {
+          return familyMemberUIDs.has(record.person_uid);
+        }
+
+        const isMale = mainStudentAssigned.person_data.male.value;
+        const isFemale = mainStudentAssigned.person_data.female.value;
+
+        return (
+          record.person_data.male.value === isMale &&
+          record.person_data.female.value === isFemale
+        );
+      }
+
+      return false;
     });
+
+    const newPersons: PersonOptionsType[] =
+      filteredPersons.map(buildPersonOption);
 
     return newPersons.sort((a, b) => {
       // If both 'weekOf' fields are empty, sort by last assistant first then by name
@@ -251,20 +258,16 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
   }, [
     persons,
     type,
-    assignmentsHistory,
-    shortDateFormat,
-    displayNameEnabled,
-    fullnameOption,
-    t,
     isAssistant,
     gender,
-    assignment,
     dataView,
-    schedule,
     assignedFSG,
     showGroupToggle,
     groupChecked,
     serviceGroups,
+    mainStudentAssigned,
+    familyMemberUIDs,
+    buildPersonOption,
   ]);
 
   const personAssigned = useMemo(() => {
@@ -274,14 +277,11 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
 
     if (!path) return null;
 
-    const dataSchedule = schedulesGetData(schedule, path);
-    let assigned: AssignmentCongregation;
-
-    if (Array.isArray(dataSchedule)) {
-      assigned = dataSchedule.find((record) => record.type === dataView);
-    } else {
-      assigned = dataSchedule;
-    }
+    const assigned = schedulesGetData(
+      schedule,
+      path,
+      dataView
+    ) as AssignmentCongregation;
 
     const person = persons.find(
       (record) => record.person_uid === assigned?.value
@@ -291,7 +291,9 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
   }, [week, assignment, dataView, schedule, persons]);
 
   const showGenderSelector = useMemo(() => {
-    if (isAssistant) return false;
+    if (isAssistant) {
+      return !!mainStudentAssigned;
+    }
 
     const validType = [
       AssignmentCode.MM_StartingConversation,
@@ -320,7 +322,7 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
     }
 
     return false;
-  }, [isAssistant, type, source, assignment, lang, sourceLocale]);
+  }, [isAssistant, type, source, assignment, lang, sourceLocale, mainStudentAssigned]);
 
   const showHeader = useMemo(
     () => showGenderSelector || showGroupToggle,
@@ -334,8 +336,10 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
       (record) => record.person_uid === personAssigned.person_uid
     );
 
-    return person || null;
-  }, [options, personAssigned]);
+    if (person) return person;
+
+    return buildPersonOption(personAssigned);
+  }, [options, personAssigned, buildPersonOption]);
 
   const personHistory = useMemo(() => {
     if (!value) return [];
@@ -425,6 +429,31 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
   const handleCloseHistory = () => setIsHistoryOpen(false);
 
   useEffect(() => {
+    if (isAssistant && mainStudentAssigned) {
+      if (!personAssigned) {
+        const studentGender = mainStudentAssigned.person_data.male.value
+          ? 'male'
+          : 'female';
+        setGender(studentGender);
+        return;
+      }
+
+      const isFamilyMember = familyMemberUIDs.has(personAssigned.person_uid);
+      const sameGender =
+        personAssigned.person_data.male.value ===
+        mainStudentAssigned.person_data.male.value;
+
+      if (isFamilyMember && !sameGender) {
+        setGender('family');
+      } else {
+        const assignedGender = personAssigned.person_data.male.value
+          ? 'male'
+          : 'female';
+        setGender(assignedGender);
+      }
+      return;
+    }
+
     if (personAssigned?.person_data.female.value) {
       setGender('female');
     }
@@ -432,7 +461,7 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
     if (personAssigned?.person_data.male.value) {
       setGender('male');
     }
-  }, [personAssigned]);
+  }, [personAssigned, isAssistant, mainStudentAssigned, familyMemberUIDs]);
 
   return {
     options,
@@ -451,6 +480,12 @@ const useStudentSelector = ({ type, assignment, week }: PersonSelectorType) => {
     helperText,
     handleToggleGroup,
     groupChecked,
+    mainStudentGender: mainStudentAssigned
+      ? mainStudentAssigned.person_data.male.value
+        ? 'male'
+        : 'female'
+      : null,
+    showFamilyFilter: familyMemberUIDs.size > 0,
   };
 };
 

--- a/src/services/app/persons.ts
+++ b/src/services/app/persons.ts
@@ -716,10 +716,6 @@ export const personIsMidweekStudent = (person: PersonType) => {
   return person.person_data.midweek_meeting_student.active.value;
 };
 
-/**
- * Get all family member UIDs for a given person (excluding the person themselves).
- * Works whether the person is a family head or a member of another head's family.
- */
 export const personGetFamilyMemberUIDs = (
   persons: PersonType[],
   personUid: string
@@ -727,14 +723,14 @@ export const personGetFamilyMemberUIDs = (
   const person = persons.find((p) => p.person_uid === personUid);
   if (!person) return new Set();
 
-  // If this person is a family head, their members are directly listed
+  // head's own UID is not stored in members[], so no need to delete self
   if (person.person_data.family_members?.head) {
     const members = new Set(person.person_data.family_members.members);
     members.delete(personUid);
     return members;
   }
 
-  // If this person is a member, find the head and get the full household
+  // person is a member — find the head and include them in the returned set
   const headPerson = persons.find(
     (p) =>
       p.person_data.family_members?.head &&

--- a/src/services/app/persons.ts
+++ b/src/services/app/persons.ts
@@ -729,7 +729,9 @@ export const personGetFamilyMemberUIDs = (
 
   // If this person is a family head, their members are directly listed
   if (person.person_data.family_members?.head) {
-    return new Set(person.person_data.family_members.members);
+    const members = new Set(person.person_data.family_members.members);
+    members.delete(personUid);
+    return members;
   }
 
   // If this person is a member, find the head and get the full household

--- a/src/services/app/persons.ts
+++ b/src/services/app/persons.ts
@@ -716,6 +716,39 @@ export const personIsMidweekStudent = (person: PersonType) => {
   return person.person_data.midweek_meeting_student.active.value;
 };
 
+/**
+ * Get all family member UIDs for a given person (excluding the person themselves).
+ * Works whether the person is a family head or a member of another head's family.
+ */
+export const personGetFamilyMemberUIDs = (
+  persons: PersonType[],
+  personUid: string
+): Set<string> => {
+  const person = persons.find((p) => p.person_uid === personUid);
+  if (!person) return new Set();
+
+  // If this person is a family head, their members are directly listed
+  if (person.person_data.family_members?.head) {
+    return new Set(person.person_data.family_members.members);
+  }
+
+  // If this person is a member, find the head and get the full household
+  const headPerson = persons.find(
+    (p) =>
+      p.person_data.family_members?.head &&
+      p.person_data.family_members.members.includes(personUid)
+  );
+
+  if (headPerson) {
+    const members = new Set(headPerson.person_data.family_members.members);
+    members.add(headPerson.person_uid);
+    members.delete(personUid);
+    return members;
+  }
+
+  return new Set();
+};
+
 export const personsSortByName = (persons: PersonType[]) => {
   const fullnameOption = store.get(fullnameOptionState);
 

--- a/src/services/app/schedules.ts
+++ b/src/services/app/schedules.ts
@@ -1683,21 +1683,9 @@ export const schedulesSelectRandomPerson = (data: {
     const isFemale = mainPerson.person_data.female.value;
 
     personsElligible = personsElligible.filter((record) => {
-      const isFamilyMembers =
-        mainPerson.person_data.family_members?.members.includes(
-          record.person_uid
-        );
-
-      const isFamilyHead = record.person_data.family_members?.members.includes(
-        mainPerson.person_uid
-      );
-
-      const isFamily = isFamilyMembers || isFamilyHead;
-
       return (
-        isFamily ||
-        (record.person_data.male.value === isMale &&
-          record.person_data.female.value === isFemale)
+        record.person_data.male.value === isMale &&
+        record.person_data.female.value === isFemale
       );
     });
   }


### PR DESCRIPTION
# Description

Implements Family radio toggle for Assistant drop-downs to fulfill #3246 and expand upon PR #4117.

- **Family Filter Toggle**: Added "Family" radio button to Assistant assignments to quickly select members of the same family household.
- **Robust Schema Resolution**: Completely replaced the `isFamily` logic to dynamically locate the Family Head conforming to the correct active `family_members` schema.
- **Autofill Protection**: Adjusted the Autocomplete scheduling service to prevent accidentally pulling cross-gender family assignments.

## Type of change

- [x] New feature

# Checklist:

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] No new warnings