### PR TITLE
tweak(reports): move back action to the navigation bar on field service report subpage

### DIFF
--- a/src/definition/app.ts
+++ b/src/definition/app.ts
@@ -94,5 +94,6 @@ export type NavBarOptionsType = {
   title?: string;
   secondaryTitle?: string;
   quickSettings?: VoidFunction;
+  onBack?: VoidFunction;
   buttons?: ReactNode;
 };

--- a/src/features/reports/field_service/persons_list/usePersonsList.tsx
+++ b/src/features/reports/field_service/persons_list/usePersonsList.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useBreakpoints } from '@hooks/index';
 import { AssignmentCode } from '@definition/assignment';
 import {
   congFieldServiceReportsState,
@@ -24,11 +23,7 @@ import { userDataViewState } from '@states/settings';
 import usePerson from '@features/persons/hooks/usePerson';
 import usePersons from '@features/persons/hooks/usePersons';
 
-let scrollPosition = 0;
-
 const usePersonsList = () => {
-  const { desktopUp } = useBreakpoints();
-
   const {
     getPublishersActive,
     getPublishersInactive,
@@ -387,28 +382,6 @@ const usePersonsList = () => {
       setSelectedPublisher(undefined);
     }
   }, [persons, setSelectedPublisher]);
-
-  useEffect(() => {
-    setTimeout(() => {
-      if (!desktopUp) {
-        if (window.scrollY !== scrollPosition) {
-          window.scrollTo({ top: scrollPosition });
-        }
-      }
-    }, 100);
-  }, [desktopUp]);
-
-  useEffect(() => {
-    const handleScroll = () => {
-      scrollPosition = window.scrollY;
-    };
-
-    window.addEventListener('scroll', handleScroll);
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, [desktopUp]);
 
   return {
     persons,

--- a/src/features/reports/field_service/report_details/index.tsx
+++ b/src/features/reports/field_service/report_details/index.tsx
@@ -1,15 +1,10 @@
 import { Box, Stack } from '@mui/material';
 import {
-  IconArrowBack,
   IconAuxiliaryPioneer,
   IconCheck,
   IconDelete,
 } from '@components/icons';
-import {
-  useAppTranslation,
-  useBreakpoints,
-  useCurrentUser,
-} from '@hooks/index';
+import { useAppTranslation, useCurrentUser } from '@hooks/index';
 import useReportDetails from './useReportDetails';
 import Button from '@components/button';
 import Card from '@components/card';
@@ -22,13 +17,10 @@ import PersonDetails from '@features/persons/person_details';
 const ReportDetails = () => {
   const { t } = useAppTranslation();
 
-  const { desktopUp } = useBreakpoints();
-
   const { isSecretary, isGroup } = useCurrentUser();
 
   const {
     person,
-    handleBack,
     enable_quick_AP,
     unverified,
     handleAssignAP,
@@ -46,37 +38,18 @@ const ReportDetails = () => {
 
       {person && (
         <Stack spacing="24px">
-          <Stack spacing="8px">
-            {!desktopUp && (
-              <Button
-                variant="small"
-                onClick={handleBack}
-                startIcon={<IconArrowBack width={18} height={18} />}
-                disableAutoStretch
-                sx={{
-                  height: '32px',
-                  minHeight: '32px',
-                  alignSelf: 'flex-start',
-                  padding: '0 8px',
-                }}
-              >
-                {t('tr_back')}
-              </Button>
-            )}
-
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '16px',
-                justifyContent: 'space-between',
-                flexWrap: 'wrap',
-              }}
-            >
-              <PersonDetails person={person} month={currentMonth} />
-              <LateReport person={person} />
-            </Box>
-          </Stack>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '16px',
+              justifyContent: 'space-between',
+              flexWrap: 'wrap',
+            }}
+          >
+            <PersonDetails person={person} month={currentMonth} />
+            <LateReport person={person} />
+          </Box>
 
           <FormS4 month={currentMonth} person_uid={person.person_uid} />
 

--- a/src/features/reports/field_service/report_details/useReportDetails.tsx
+++ b/src/features/reports/field_service/report_details/useReportDetails.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue } from 'jotai';
 import {
   congFieldServiceReportsState,
   selectedMonthFieldServiceReportState,
@@ -24,7 +24,7 @@ const useReportDetails = () => {
     personIsUnbaptizedPublisher,
   } = usePerson();
 
-  const [publisher, setPublisher] = useAtom(selectedPublisherReportState);
+  const publisher = useAtomValue(selectedPublisherReportState);
 
   const persons = useAtomValue(personsState);
   const currentMonth = useAtomValue(selectedMonthFieldServiceReportState);
@@ -135,8 +135,6 @@ const useReportDetails = () => {
 
     return report ? true : false;
   }, [report, report_editable, person]);
-
-  const handleBack = () => setPublisher(undefined);
 
   const handleAssignAP = async () => {
     try {
@@ -254,7 +252,6 @@ const useReportDetails = () => {
 
   return {
     person,
-    handleBack,
     enable_quick_AP,
     unverified,
     handleAssignAP,

--- a/src/features/reports/field_service/selector_stats/index.tsx
+++ b/src/features/reports/field_service/selector_stats/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Stack } from '@mui/material';
+import { Box, Collapse, Stack } from '@mui/material';
+import { SelectorStatsProps } from './index.types';
 import useSelectorStats from './useSelectorStats';
 import Card from '@components/card';
 import Divider from '@components/divider';
@@ -9,13 +10,13 @@ import { IconInfo } from '@components/icons';
 import Typography from '@components/typography';
 import { t } from 'i18next';
 
-const SelectorStats = () => {
+const SelectorStats = ({ hideStats = false }: SelectorStatsProps) => {
   const { handleMonthChange, handleYearChange, month, year, month_locked } =
     useSelectorStats();
 
   return (
     <Card>
-      <Stack spacing="24px" divider={<Divider color="var(--accent-200)" />}>
+      <Stack>
         <Stack spacing="24px">
           <ServiceYearMonthSelector
             year={year}
@@ -43,10 +44,13 @@ const SelectorStats = () => {
           )}
         </Stack>
 
-        <Stack spacing="24px">
-          <ReceivedReports />
-          <PersonFilter />
-        </Stack>
+        <Collapse in={!hideStats}>
+          <Stack spacing="24px" sx={{ paddingTop: '24px' }}>
+            <Divider color="var(--accent-200)" />
+            <ReceivedReports />
+            <PersonFilter />
+          </Stack>
+        </Collapse>
       </Stack>
     </Card>
   );

--- a/src/features/reports/field_service/selector_stats/index.types.ts
+++ b/src/features/reports/field_service/selector_stats/index.types.ts
@@ -1,0 +1,3 @@
+export type SelectorStatsProps = {
+  hideStats?: boolean;
+};

--- a/src/layouts/navbar/useNavbar.tsx
+++ b/src/layouts/navbar/useNavbar.tsx
@@ -69,6 +69,11 @@ const useNavbar = () => {
   };
 
   const handleBack = () => {
+    if (navBarOptions.onBack) {
+      navBarOptions.onBack();
+      return;
+    }
+
     if (window.history.length > 1) {
       navigate(-1);
     } else {

--- a/src/pages/reports/field_service/index.tsx
+++ b/src/pages/reports/field_service/index.tsx
@@ -20,7 +20,10 @@ const FieldService = () => {
 
   const { isSecretary, isGroup } = useCurrentUser();
 
-  const { editorOpen, handleOpenBranchReport } = useFieldService();
+  const { editorOpen, handleOpenBranchReport, selectedPersonName, handleBack } =
+    useFieldService();
+
+  const isPersonSubpage = !desktopUp && editorOpen;
 
   return (
     <Box
@@ -31,21 +34,29 @@ const FieldService = () => {
         paddingBottom: !tablet688Up ? '60px' : '0px',
       }}
     >
-      <PageTitle
-        title={t('tr_fieldServiceReports')}
-        buttons={
-          !isGroup &&
-          isSecretary && (
-            <NavBarButtonGroup>
-              <NavBarButton
-                text={t('tr_createS1')}
-                icon={<IconPrepareReport />}
-                onClick={handleOpenBranchReport}
-              ></NavBarButton>
-            </NavBarButtonGroup>
-          )
-        }
-      />
+      {isPersonSubpage ? (
+        <PageTitle
+          title={selectedPersonName}
+          secondaryTitle={t('tr_fieldServiceReports')}
+          onBack={handleBack}
+        />
+      ) : (
+        <PageTitle
+          title={t('tr_fieldServiceReports')}
+          buttons={
+            !isGroup &&
+            isSecretary && (
+              <NavBarButtonGroup>
+                <NavBarButton
+                  text={t('tr_createS1')}
+                  icon={<IconPrepareReport />}
+                  onClick={handleOpenBranchReport}
+                ></NavBarButton>
+              </NavBarButtonGroup>
+            )
+          }
+        />
+      )}
 
       <Box
         sx={{
@@ -58,7 +69,7 @@ const FieldService = () => {
         }}
       >
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-          <SelectorStats />
+          <SelectorStats hideStats={isPersonSubpage} />
 
           {desktopUp && <PersonsList />}
 

--- a/src/pages/reports/field_service/useFieldService.tsx
+++ b/src/pages/reports/field_service/useFieldService.tsx
@@ -20,7 +20,7 @@ const useFieldService = () => {
   const persons = useAtomValue(personsState);
 
   const listScrollPosition = useRef(0);
-  const prevEditorOpen = useRef(false);
+  const prevMobileEditor = useRef(false);
 
   const editorOpen = useMemo(() => {
     return selectedPublisher ? true : false;
@@ -34,19 +34,20 @@ const useFieldService = () => {
     return person ? getName(person) : '';
   }, [persons, selectedPublisher, getName]);
 
-  // on mobile the list and the person report swap in place: opening a report
-  // starts it at the top of the page, going back restores the list scroll
+  // on mobile the list and the person report swap in place: entering the report
+  // (either by opening it or by shrinking to mobile while it is open) starts at
+  // the top of the page and captures the list scroll, going back restores it
   useLayoutEffect(() => {
-    if (prevEditorOpen.current === editorOpen) return;
+    const mobileEditor = !desktopUp && editorOpen;
 
-    prevEditorOpen.current = editorOpen;
+    if (mobileEditor === prevMobileEditor.current) return;
 
-    if (desktopUp) return;
+    prevMobileEditor.current = mobileEditor;
 
-    if (editorOpen) {
+    if (mobileEditor) {
       listScrollPosition.current = window.scrollY;
       window.scrollTo({ top: 0 });
-    } else {
+    } else if (!editorOpen) {
       window.scrollTo({ top: listScrollPosition.current });
     }
   }, [editorOpen, desktopUp]);

--- a/src/pages/reports/field_service/useFieldService.tsx
+++ b/src/pages/reports/field_service/useFieldService.tsx
@@ -1,22 +1,68 @@
-import { useMemo } from 'react';
+import { useLayoutEffect, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router';
-import { useAtomValue } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
+import { useBreakpoints } from '@hooks/index';
 import { selectedPublisherReportState } from '@states/field_service_reports';
+import { personsState } from '@states/persons';
+import usePerson from '@features/persons/hooks/usePerson';
 
 const useFieldService = () => {
   const navigate = useNavigate();
 
-  const selectedPublisher = useAtomValue(selectedPublisherReportState);
+  const { desktopUp } = useBreakpoints();
+
+  const { getName } = usePerson();
+
+  const [selectedPublisher, setSelectedPublisher] = useAtom(
+    selectedPublisherReportState
+  );
+
+  const persons = useAtomValue(personsState);
+
+  const listScrollPosition = useRef(0);
+  const prevEditorOpen = useRef(false);
 
   const editorOpen = useMemo(() => {
     return selectedPublisher ? true : false;
   }, [selectedPublisher]);
 
+  const selectedPersonName = useMemo(() => {
+    const person = persons.find(
+      (record) => record.person_uid === selectedPublisher
+    );
+
+    return person ? getName(person) : '';
+  }, [persons, selectedPublisher, getName]);
+
+  // on mobile the list and the person report swap in place: opening a report
+  // starts it at the top of the page, going back restores the list scroll
+  useLayoutEffect(() => {
+    if (prevEditorOpen.current === editorOpen) return;
+
+    prevEditorOpen.current = editorOpen;
+
+    if (desktopUp) return;
+
+    if (editorOpen) {
+      listScrollPosition.current = window.scrollY;
+      window.scrollTo({ top: 0 });
+    } else {
+      window.scrollTo({ top: listScrollPosition.current });
+    }
+  }, [editorOpen, desktopUp]);
+
   const handleOpenBranchReport = () => {
     navigate('/reports/branch-office');
   };
 
-  return { editorOpen, handleOpenBranchReport };
+  const handleBack = () => setSelectedPublisher(undefined);
+
+  return {
+    editorOpen,
+    handleOpenBranchReport,
+    selectedPersonName,
+    handleBack,
+  };
 };
 
 export default useFieldService;


### PR DESCRIPTION
# Description

On mobile, opening a publisher's field service report now uses the app's **subpage navigation bar** (back arrow + publisher name with "Field service reports" underneath) instead of a back button inside the report card, matching the pattern used by other subpages.

Along with moving the back action:
- The congregation-wide stats block (received reports progress + person filter) is hidden while viewing a single publisher, since those are list-level context — animated with `Collapse` so it doesn't pop.
- The list scroll position is preserved when opening/closing a report, so the slide transitions stay smooth and return you exactly where you left the list. This replaces an older module-level scroll handler in `usePersonsList`.

Desktop behavior is unchanged (list and detail remain side-by-side; the same page title and stats render).

Fixes # (n/a)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
