### PR TITLE
fix: preserve date when manually entering the year

### DIFF
--- a/src/components/date_picker/index.tsx
+++ b/src/components/date_picker/index.tsx
@@ -71,7 +71,12 @@ const DatePicker = ({
 
     const isValidDate = value instanceof Date && isValid(value);
 
-    onChange?.(value);
+    // Only push a complete valid date or a fully cleared field up to the parent.
+    // A partial manual entry (e.g. while typing the year) arrives as an Invalid
+    // Date and would otherwise clear the stored value.
+    if (isValidDate || value === null) {
+      onChange?.(value);
+    }
 
     if (view === 'input' && !open && isValidDate) {
       setOpen(false);

--- a/src/components/date_picker/index.tsx
+++ b/src/components/date_picker/index.tsx
@@ -34,6 +34,10 @@ const DatePicker = ({
   error,
   helperText,
 }: CustomDatePickerProps) => {
+  // Years below this threshold are transient artifacts of typing the year
+  // section (e.g. 0002 while entering 2026) and must not be propagated.
+  const MIN_VALID_YEAR = 1000;
+
   const poperRef = useRef<HTMLDivElement>(null);
 
   const shortDateFormatDefault = useAtomValue(shortDateFormatState);
@@ -66,17 +70,23 @@ const DatePicker = ({
     setOpen(false);
   };
 
-  const handleValueChange = (value: Date | null) => {
-    setValueTmp(value);
+  const handleValueChange = (newValue: Date | null) => {
+    const isValidDate = newValue instanceof Date && isValid(newValue);
 
-    const isValidDate = value instanceof Date && isValid(value);
+    // Mirror every change locally so the controlled picker stays in sync
+    // with its own field state. Only settled values reach the parent:
+    // incomplete drafts and the low-year artifacts emitted while typing
+    // the year section (e.g. 0002 en route to 2026) must not propagate,
+    // since parents stringify and parse them back as a different date,
+    // which scrambles or wipes the entry. An explicit clear (null) is
+    // always forwarded.
+    setValueTmp(newValue);
 
-    // Only push a complete valid date or a fully cleared field up to the parent.
-    // A partial manual entry (e.g. while typing the year) arrives as an Invalid
-    // Date and would otherwise clear the stored value.
-    if (isValidDate || value === null) {
-      onChange?.(value);
-    }
+    if (!isValidDate && newValue !== null) return;
+
+    if (isValidDate && newValue.getFullYear() < MIN_VALID_YEAR) return;
+
+    onChange?.(newValue);
 
     if (view === 'input' && !open && isValidDate) {
       setOpen(false);

--- a/src/components/date_picker/index.tsx
+++ b/src/components/date_picker/index.tsx
@@ -66,6 +66,8 @@ const DatePicker = ({
 
     if (!isValidDate) return;
 
+    if (valueTmp.getFullYear() < MIN_VALID_YEAR) return;
+
     onChange?.(valueTmp);
     setOpen(false);
   };
@@ -106,7 +108,19 @@ const DatePicker = ({
   }, [valueTmp]);
 
   useEffect(() => {
-    setValueTmp(value ?? null);
+    setValueTmp((prev) => {
+      const next = value ?? null;
+
+      if (prev === null && next === null) return prev;
+      if (
+        prev instanceof Date &&
+        next instanceof Date &&
+        prev.getTime() === next.getTime()
+      )
+        return prev;
+
+      return next;
+    });
   }, [value]);
 
   return (


### PR DESCRIPTION
### What this fixes

Closes #5072.

When manually typing a date, tabbing into or editing the year field made the whole entry disappear or scramble. Two things were going wrong:

1. While typing the year section, MUI emits *valid* intermediate dates (e.g. `0002-09-15` on the way to `2026`). These were forwarded to the parent, which stores a string and hands back `new Date("0002/09/15")` — browsers parse that as a completely different date (e.g. Feb 9, 2015), so the displayed value scrambled and subsequent keystrokes derailed until the entry was wiped.
2. Incomplete manual entries arrived as an `Invalid Date`, which also wiped the stored value when forwarded.

### The change

In `handleValueChange` (`src/components/date_picker/index.tsx`), every change is still mirrored into the picker's local state (required — MUI v8 de-syncs and clears its field if the controlled value ignores its internal changes), but only settled values are propagated to the parent:

- complete valid dates with year >= 1000,
- explicit clears (`null`, e.g. keyboard drain-clear or the widget's clear action).

Incomplete drafts and year-typing artifacts stay local, so partial typing no longer clears anything and the year can be typed digit-by-digit normally.

### Testing

Verified in a browser against this component wired exactly like the Time away editor:

- Typing DD → MM → YYYY into an empty date now completes cleanly (`15/09/2026` stored) with a single `onChange`.
- Editing only the year of a prefilled date keeps day/month (`24/08/2030`) instead of wiping them.
- Draining all sections with Backspace forwards `null` (stored end date cleared).
- Abandoning an incomplete entry and blurring leaves the stored value untouched.
- Calendar widget selection still propagates immediately.
- `npm run build` passes and `eslint` is clean on the changed file.

Scope is intentionally kept to the disappearing/scrambling-value bug. The other UX points in the issue (focus retention, widget max-height, end-date-before-start validation, widget opening on the start month) remain separate follow-ups.
