### PR TITLE
tweak(ui): update action buttons design, interactions and stacking

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -25,6 +25,24 @@ const Button: FC<ButtonPropsType> = (props) => {
 
   if (variant === 'small') className = 'body-small-semibold';
 
+  const isGradient = variant === 'main';
+
+  const gradientTop = color
+    ? `color-mix(in oklch, var(--${color}-main), white 15%)`
+    : 'var(--accent-gradient-top)';
+  const topHighlight = `linear-gradient(180deg, ${gradientTop} 0%, transparent 100%)`;
+  const overlayBorder =
+    'linear-gradient(180deg, rgba(255, 255, 255, 0.24) 0%, rgba(255, 255, 255, 0) 100%)';
+  const gradientBackground = `${topHighlight}, ${overlayBorder}`;
+
+  const darkenOverlay = 'inset 0 0 0 1000px var(--btn-hover-overlay)';
+  const noOverlay = 'inset 0 0 0 1000px rgba(var(--accent-dark-overlay-base), 0)';
+
+  const springEasing = 'cubic-bezier(0.34, 1.56, 0.64, 1)';
+
+  const hasPressScale =
+    isGradient || variant === 'secondary' || variant === 'tertiary';
+
   const getBackgroundColor = () => {
     let result = '';
 
@@ -217,23 +235,37 @@ const Button: FC<ButtonPropsType> = (props) => {
         fontFeatureSettings: '"cv05"',
         padding: variant === 'small' ? '4px 8px' : '8px 16px',
         backgroundColor: getBackgroundColor(),
-        border:
-          internalVariant === 'outlined'
+        ...(isGradient && {
+          backgroundImage: gradientBackground,
+          backgroundOrigin: 'border-box',
+          backgroundClip: 'padding-box, border-box',
+        }),
+        ...(hasPressScale && {
+          transition: isGradient
+            ? `box-shadow 0.2s ease, transform 0.22s ${springEasing}`
+            : `background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.22s ${springEasing}`,
+        }),
+        border: isGradient
+          ? '2px solid transparent'
+          : internalVariant === 'outlined'
             ? '1px solid var(--accent-dark)'
             : 'none',
         color: getColor(),
-        boxShadow: 'none',
+        boxShadow: isGradient ? noOverlay : 'none',
         borderRadius:
           variant === 'small' || variant === 'semi-white'
             ? 'var(--radius-m)'
             : 'var(--radius-l)',
         '&:hover': {
-          backgroundColor: getBackgroundColorHover(),
-          border:
-            internalVariant === 'outlined'
+          backgroundColor: isGradient
+            ? getBackgroundColor()
+            : getBackgroundColorHover(),
+          boxShadow: isGradient ? darkenOverlay : 'none',
+          border: isGradient
+            ? '2px solid transparent'
+            : internalVariant === 'outlined'
               ? '1px solid var(--accent-dark)'
               : 'none',
-          boxShadow: 'none',
           borderRadius:
             variant === 'group'
               ? 'none'
@@ -242,6 +274,7 @@ const Button: FC<ButtonPropsType> = (props) => {
                 : 'var(--radius-l)',
           '@media (hover: none)': {
             backgroundColor: getBackgroundColor(),
+            ...(isGradient && { boxShadow: noOverlay }),
           },
         },
 
@@ -250,12 +283,16 @@ const Button: FC<ButtonPropsType> = (props) => {
         },
 
         '&:active': {
-          backgroundColor: getBackgroundColorClick(),
-          border:
-            internalVariant === 'outlined'
+          backgroundColor: isGradient
+            ? getBackgroundColor()
+            : getBackgroundColorClick(),
+          ...(hasPressScale && { transform: 'scale(0.985)' }),
+          boxShadow: isGradient ? noOverlay : 'none',
+          border: isGradient
+            ? '2px solid transparent'
+            : internalVariant === 'outlined'
               ? '1px solid var(--accent-dark)'
               : 'none',
-          boxShadow: 'none',
           borderRadius:
             variant === 'group'
               ? 'none'
@@ -264,14 +301,16 @@ const Button: FC<ButtonPropsType> = (props) => {
                 : variant === 'semi-white'
                   ? 'var(--radius-m)'
                   : 'var(--radius-l)',
-          opacity: variant === 'small' || color ? 0.8 : 1,
+          opacity: !isGradient && (variant === 'small' || color) ? 0.8 : 1,
         },
         '&:disabled': {
           backgroundColor:
             internalVariant === 'contained' ? 'var(--accent-150)' : 'unset',
+          ...(isGradient && { backgroundImage: 'none' }),
           color: 'var(--accent-350)',
-          border:
-            internalVariant === 'outlined'
+          border: isGradient
+            ? '2px solid transparent'
+            : internalVariant === 'outlined'
               ? '1px solid var(--accent-200)'
               : 'none',
         },

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -43,6 +43,18 @@ const Button: FC<ButtonPropsType> = (props) => {
   const hasPressScale =
     isGradient || variant === 'secondary' || variant === 'tertiary';
 
+  const getBorder = (isDisabled = false) => {
+    if (isGradient) {
+      return '2px solid transparent';
+    }
+
+    if (internalVariant !== 'outlined') {
+      return 'none';
+    }
+
+    return `1px solid var(--accent-${isDisabled ? '200' : 'dark'})`;
+  };
+
   const getBackgroundColor = () => {
     let result = '';
 
@@ -245,11 +257,7 @@ const Button: FC<ButtonPropsType> = (props) => {
             ? `box-shadow 0.2s ease, transform 0.22s ${springEasing}`
             : `background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.22s ${springEasing}`,
         }),
-        border: isGradient
-          ? '2px solid transparent'
-          : internalVariant === 'outlined'
-            ? '1px solid var(--accent-dark)'
-            : 'none',
+        border: getBorder(),
         color: getColor(),
         boxShadow: isGradient ? noOverlay : 'none',
         borderRadius:
@@ -261,11 +269,7 @@ const Button: FC<ButtonPropsType> = (props) => {
             ? getBackgroundColor()
             : getBackgroundColorHover(),
           boxShadow: isGradient ? darkenOverlay : 'none',
-          border: isGradient
-            ? '2px solid transparent'
-            : internalVariant === 'outlined'
-              ? '1px solid var(--accent-dark)'
-              : 'none',
+          border: getBorder(),
           borderRadius:
             variant === 'group'
               ? 'none'
@@ -288,11 +292,7 @@ const Button: FC<ButtonPropsType> = (props) => {
             : getBackgroundColorClick(),
           ...(hasPressScale && { transform: 'scale(0.985)' }),
           boxShadow: isGradient ? noOverlay : 'none',
-          border: isGradient
-            ? '2px solid transparent'
-            : internalVariant === 'outlined'
-              ? '1px solid var(--accent-dark)'
-              : 'none',
+          border: getBorder(),
           borderRadius:
             variant === 'group'
               ? 'none'
@@ -308,11 +308,7 @@ const Button: FC<ButtonPropsType> = (props) => {
             internalVariant === 'contained' ? 'var(--accent-150)' : 'unset',
           ...(isGradient && { backgroundImage: 'none' }),
           color: 'var(--accent-350)',
-          border: isGradient
-            ? '2px solid transparent'
-            : internalVariant === 'outlined'
-              ? '1px solid var(--accent-200)'
-              : 'none',
+          border: getBorder(true),
         },
         '& svg': {
           height: variant === 'small' ? '20px' : '22px',

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -31,9 +31,11 @@ const Button: FC<ButtonPropsType> = (props) => {
     ? `color-mix(in oklch, var(--${color}-main), white 15%)`
     : 'var(--accent-gradient-top)';
   const topHighlight = `linear-gradient(180deg, ${gradientTop} 0%, transparent 100%)`;
-  const overlayBorder =
-    'linear-gradient(180deg, rgba(255, 255, 255, 0.32) 0%, rgba(0, 0, 0, 0.05) 100%)';
-  const gradientBackground = `${topHighlight}, ${overlayBorder}`;
+  const overlayBorderTop =
+    'linear-gradient(180deg, rgba(255, 255, 255, 0.32) 0%, rgba(255, 255, 255, 0) 100%)';
+  const overlayBorderBottom =
+    'linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.05) 100%)';
+  const gradientBackground = `${topHighlight}, ${overlayBorderTop}, ${overlayBorderBottom}`;
 
   const darkenOverlay = 'inset 0 0 0 1000px var(--btn-hover-overlay)';
   const noOverlay =
@@ -251,7 +253,7 @@ const Button: FC<ButtonPropsType> = (props) => {
         ...(isGradient && {
           backgroundImage: gradientBackground,
           backgroundOrigin: 'border-box',
-          backgroundClip: 'padding-box, border-box',
+          backgroundClip: 'padding-box, border-box, border-box',
         }),
         ...(hasPressScale && {
           transition: isGradient

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -32,11 +32,12 @@ const Button: FC<ButtonPropsType> = (props) => {
     : 'var(--accent-gradient-top)';
   const topHighlight = `linear-gradient(180deg, ${gradientTop} 0%, transparent 100%)`;
   const overlayBorder =
-    'linear-gradient(180deg, rgba(255, 255, 255, 0.24) 0%, rgba(255, 255, 255, 0) 100%)';
+    'linear-gradient(180deg, rgba(255, 255, 255, 0.32) 0%, rgba(0, 0, 0, 0.05) 100%)';
   const gradientBackground = `${topHighlight}, ${overlayBorder}`;
 
   const darkenOverlay = 'inset 0 0 0 1000px var(--btn-hover-overlay)';
-  const noOverlay = 'inset 0 0 0 1000px rgba(var(--accent-dark-overlay-base), 0)';
+  const noOverlay =
+    'inset 0 0 0 1000px rgba(var(--accent-dark-overlay-base), 0)';
 
   const springEasing = 'cubic-bezier(0.34, 1.56, 0.64, 1)';
 

--- a/src/components/dialog_actions/index.tsx
+++ b/src/components/dialog_actions/index.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react';
+import { Box } from '@mui/material';
+import { useBreakpoints } from '@hooks/index';
+import { DialogActionsProps } from './index.types';
+
+const DialogActions: FC<DialogActionsProps> = ({ children, sx }) => {
+  const { tabletUp } = useBreakpoints();
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: tabletUp ? 'row' : 'column-reverse',
+        gap: '8px',
+        width: '100%',
+        ...(tabletUp && {
+          '& > :last-child': { marginLeft: 'auto' },
+          '&& > *': { minWidth: '96px' },
+        }),
+        ...sx,
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default DialogActions;

--- a/src/components/dialog_actions/index.types.ts
+++ b/src/components/dialog_actions/index.types.ts
@@ -1,0 +1,7 @@
+import { ReactNode } from 'react';
+import { SxProps, Theme } from '@mui/material';
+
+export type DialogActionsProps = {
+  children: ReactNode;
+  sx?: SxProps<Theme>;
+};

--- a/src/features/app_start/vip/terms_use/index.tsx
+++ b/src/features/app_start/vip/terms_use/index.tsx
@@ -1,8 +1,9 @@
-import { Box, Stack } from '@mui/material';
+import { Box } from '@mui/material';
 import { useAppTranslation } from '@hooks/index';
 import useTermsUse from './useTermsUse';
 import Button from '@components/button';
 import Checkbox from '@components/checkbox';
+import DialogActions from '@components/dialog_actions';
 import Dialog from '../../../../components/dialog';
 import TextMarkup from '@components/text_markup';
 import Typography from '@components/typography';
@@ -76,7 +77,15 @@ const TermsUse = () => {
           }
         />
 
-        <Stack spacing="8px" width="100%">
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleRejectTerms}
+            sx={{ flex: 1 }}
+          >
+            {t('tr_cancel')}
+          </Button>
+
           <Button
             variant="main"
             disabled={!readComplete}
@@ -85,15 +94,7 @@ const TermsUse = () => {
           >
             {t('tr_next')}
           </Button>
-
-          <Button
-            variant="secondary"
-            onClick={handleRejectTerms}
-            sx={{ flex: 1 }}
-          >
-            {t('tr_cancel')}
-          </Button>
-        </Stack>
+        </DialogActions>
       </Box>
     </Dialog>
   );

--- a/src/features/congregation/app_access/join_requests/accept/index.tsx
+++ b/src/features/congregation/app_access/join_requests/accept/index.tsx
@@ -9,6 +9,7 @@ import Autocomplete from '@components/autocomplete';
 import Button from '@components/button';
 import Checkbox from '@components/checkbox';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import SwitchWithLabel from '@components/switch_with_label';
 import Typography from '@components/typography';
 
@@ -159,21 +160,14 @@ const AcceptRequest = (props: AcceptRequestProps) => {
           </Stack>
         </Stack>
 
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '8px',
-            width: '100%',
-          }}
-        >
-          <Button variant="main" onClick={handleConfirm}>
-            {t('tr_continue')}
-          </Button>
+        <DialogActions>
           <Button variant="secondary" onClick={handleClose}>
             {t('tr_cancel')}
           </Button>
-        </Box>
+          <Button variant="main" onClick={handleConfirm}>
+            {t('tr_continue')}
+          </Button>
+        </DialogActions>
       </Dialog>
     </>
   );

--- a/src/features/congregation/app_access/user_add/person_select/index.tsx
+++ b/src/features/congregation/app_access/user_add/person_select/index.tsx
@@ -4,6 +4,7 @@ import { useAppTranslation } from '@hooks/index';
 import usePersonSelect from './usePersonSelect';
 import Autocomplete from '@components/autocomplete';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import Radio from '@components/radio';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
@@ -117,14 +118,12 @@ const PersonSelect = (props: PersonSelectType) => {
         )}
       />
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={handleSecondaryAction}>
+          {userType !== 'baptized' || !searchStatus
+            ? t('tr_cancel')
+            : t('tr_back')}
+        </Button>
         <Button
           variant="main"
           endIcon={
@@ -138,12 +137,7 @@ const PersonSelect = (props: PersonSelectType) => {
             ? t('tr_searchUser')
             : t('tr_bindUser')}
         </Button>
-        <Button variant="secondary" onClick={handleSecondaryAction}>
-          {userType !== 'baptized' || !searchStatus
-            ? t('tr_cancel')
-            : t('tr_back')}
-        </Button>
-      </Box>
+      </DialogActions>
     </>
   );
 };

--- a/src/features/congregation/app_access/user_details/delete_user/index.tsx
+++ b/src/features/congregation/app_access/user_details/delete_user/index.tsx
@@ -5,6 +5,7 @@ import { DeleteUserType } from './index.types';
 import useDeleteUser from './useDeleteUser';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import Markup from '@components/text_markup';
 
@@ -25,14 +26,10 @@ const DeleteUser = ({ open, onClose, user }: DeleteUserType) => {
         />
       </Box>
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           color="red"
@@ -42,10 +39,7 @@ const DeleteUser = ({ open, onClose, user }: DeleteUserType) => {
         >
           {t('tr_delete')}
         </Button>
-        <Button variant="secondary" onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/congregation/app_access/user_details/invitation_code/delete_code/index.tsx
+++ b/src/features/congregation/app_access/user_details/invitation_code/delete_code/index.tsx
@@ -5,6 +5,7 @@ import { DeleteCodeType } from './index.types';
 import useDeleteCode from './useDeleteCode';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 
 const DeleteCode = ({ open, onClose, user }: DeleteCodeType) => {
@@ -22,14 +23,10 @@ const DeleteCode = ({ open, onClose, user }: DeleteCodeType) => {
         </Typography>
       </Box>
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           color="red"
@@ -39,10 +36,7 @@ const DeleteCode = ({ open, onClose, user }: DeleteCodeType) => {
         >
           {t('tr_delete')}
         </Button>
-        <Button variant="secondary" onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/congregation/field_service_groups/create_group/group_details/index.tsx
+++ b/src/features/congregation/field_service_groups/create_group/group_details/index.tsx
@@ -5,6 +5,7 @@ import { GroupDetailsProps, UsersOption } from './index.types';
 import useGroupDetails from './useGroupDetails';
 import Autocomplete from '@components/autocomplete';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import TextField from '@components/textfield';
 
@@ -114,14 +115,14 @@ const GroupDetails = (props: GroupDetailsProps) => {
         </Box>
       </Stack>
 
-      <Stack spacing="8px">
-        <Button variant="main" onClick={props.action}>
-          {t('tr_next')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button variant="main" onClick={props.action}>
+          {t('tr_next')}
+        </Button>
+      </DialogActions>
     </Stack>
   );
 };

--- a/src/features/congregation/field_service_groups/create_group/new_group_members/index.tsx
+++ b/src/features/congregation/field_service_groups/create_group/new_group_members/index.tsx
@@ -2,6 +2,7 @@ import { Box, Stack } from '@mui/material';
 import { useAppTranslation } from '@hooks/index';
 import { NewGroupMembersProps } from './index.types';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import GroupMembers from '../../group_members';
 import Typography from '@components/typography';
 
@@ -28,21 +29,14 @@ const NewGroupMembers = ({
 
       <GroupMembers group={group} onChange={onChange} />
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <Button variant="main" onClick={action}>
-          {t('tr_create')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={onBack}>
           {t('tr_back')}
         </Button>
-      </Box>
+        <Button variant="main" onClick={action}>
+          {t('tr_create')}
+        </Button>
+      </DialogActions>
     </Stack>
   );
 };

--- a/src/features/congregation/field_service_groups/group_delete/index.tsx
+++ b/src/features/congregation/field_service_groups/group_delete/index.tsx
@@ -3,6 +3,7 @@ import { useAppTranslation } from '@hooks/index';
 import { GroupDeleteProps } from './index.types';
 import useGroupDelete from './useGroupDelete';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 
 const GroupDelete = (props: GroupDeleteProps) => {
@@ -22,14 +23,14 @@ const GroupDelete = (props: GroupDeleteProps) => {
         </Typography>
       </Stack>
 
-      <Stack spacing="8px" width="100%">
-        <Button variant="main" color="red" onClick={handleDeleteGroup}>
-          {t('tr_delete')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button variant="main" color="red" onClick={handleDeleteGroup}>
+          {t('tr_delete')}
+        </Button>
+      </DialogActions>
     </>
   );
 };

--- a/src/features/congregation/field_service_groups/group_edit/index.tsx
+++ b/src/features/congregation/field_service_groups/group_edit/index.tsx
@@ -1,9 +1,10 @@
-import { Box, Stack } from '@mui/material';
+import { Box } from '@mui/material';
 import { IconDelete } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { GroupEditProps } from './index.types';
 import useGroupEdit from './useGroupEdit';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import GroupMembers from '../group_members';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
@@ -54,14 +55,14 @@ const GroupEdit = (props: GroupEditProps) => {
 
       <GroupMembers group={tmpGroup} onChange={handleGroupUpdate} />
 
-      <Stack spacing="8px" width="100%">
-        <Button variant="main" onClick={handleSaveChanges}>
-          {t('tr_save')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button variant="main" onClick={handleSaveChanges}>
+          {t('tr_save')}
+        </Button>
+      </DialogActions>
     </>
   );
 };

--- a/src/features/congregation/field_service_groups/group_item/remove_person/index.tsx
+++ b/src/features/congregation/field_service_groups/group_item/remove_person/index.tsx
@@ -4,6 +4,7 @@ import { RemovePersonProps } from './index.types';
 import useRemovePerson from './useRemovePerson';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Markup from '@components/text_markup';
 import Typography from '@components/typography';
 
@@ -26,14 +27,14 @@ const RemovePerson = (props: RemovePersonProps) => {
         />
       </Stack>
 
-      <Stack spacing="8px" width="100%">
-        <Button variant="main" color="red" onClick={props.action}>
-          {t('tr_remove')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button variant="main" color="red" onClick={props.action}>
+          {t('tr_remove')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/congregation/field_service_groups/groups_reorder/index.tsx
+++ b/src/features/congregation/field_service_groups/groups_reorder/index.tsx
@@ -1,4 +1,3 @@
-import { Stack } from '@mui/material';
 import { ReactSortable } from 'react-sortablejs';
 import { useAppTranslation } from '@hooks/index';
 import { GroupsReorderProps } from './index.types';
@@ -6,6 +5,7 @@ import { GroupsContainer } from './index.styles';
 import useGroupsReorder from './useGroupsReorder';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import GroupItem from './group_item';
 import Typography from '@components/typography';
 
@@ -31,14 +31,14 @@ const GroupsReorder = (props: GroupsReorderProps) => {
         </ReactSortable>
       </GroupsContainer>
 
-      <Stack spacing="8px" width="100%">
-        <Button variant="main" onClick={handleSaveChanges}>
-          {t('tr_save')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button variant="main" onClick={handleSaveChanges}>
+          {t('tr_save')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/congregation/settings/congregation_privacy/access_code_change/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/access_code_change/index.tsx
@@ -6,6 +6,7 @@ import { AccessCodeChangeType } from './index.types';
 import useAccessCodeChange from './useAccessCodeChange';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
 
@@ -69,14 +70,10 @@ const AccessCodeChange = ({ open, onClose }: AccessCodeChangeType) => {
         resetHelperPadding={true}
       />
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           disabled={isProcessing}
@@ -85,10 +82,7 @@ const AccessCodeChange = ({ open, onClose }: AccessCodeChangeType) => {
         >
           {t('tr_save')}
         </Button>
-        <Button variant="secondary" onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/congregation/settings/congregation_privacy/delete_congregation/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/delete_congregation/index.tsx
@@ -5,6 +5,7 @@ import { useAppTranslation } from '@hooks/index';
 import useDeleteCongregation from './useDeleteCongregation';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
 
@@ -48,14 +49,14 @@ const DeleteCongregation = () => {
             resetHelperPadding={true}
           />
 
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '8px',
-              width: '100%',
-            }}
-          >
+          <DialogActions>
+            <Button
+              variant="secondary"
+              disabled={isProcessing}
+              onClick={handleDeleteClose}
+            >
+              {t('tr_cancel')}
+            </Button>
             <Button
               variant="main"
               color="red"
@@ -65,14 +66,7 @@ const DeleteCongregation = () => {
             >
               {t('tr_delete')}
             </Button>
-            <Button
-              variant="secondary"
-              disabled={isProcessing}
-              onClick={handleDeleteClose}
-            >
-              {t('tr_cancel')}
-            </Button>
-          </Box>
+          </DialogActions>
         </Dialog>
       )}
 

--- a/src/features/congregation/settings/congregation_privacy/master_key_change/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/master_key_change/index.tsx
@@ -6,6 +6,7 @@ import { MasterKeyChangeType } from './index.types';
 import useMasterKeyChange from './useMasterKeyChange';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
 
@@ -69,14 +70,10 @@ const MasterKeyChange = ({ open, onClose }: MasterKeyChangeType) => {
         resetHelperPadding={true}
       />
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           disabled={isProcessing}
@@ -85,10 +82,7 @@ const MasterKeyChange = ({ open, onClose }: MasterKeyChangeType) => {
         >
           {t('tr_save')}
         </Button>
-        <Button variant="secondary" onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/congregation/settings/import_export/confirm_import/index.tsx
+++ b/src/features/congregation/settings/import_export/confirm_import/index.tsx
@@ -5,6 +5,7 @@ import { useAppTranslation, useBreakpoints } from '@hooks/index';
 import useConfirmImport from './useConfirmImport';
 import Button from '@components/button';
 import Checkbox from '@components/checkbox';
+import DialogActions from '@components/dialog_actions';
 import Divider from '@components/divider';
 import IconLoading from '@components/icon_loading';
 import Typography from '@components/typography';
@@ -258,7 +259,10 @@ const ConfirmImport = (props: ConfirmImportProps) => {
         </Stack>
       </Stack>
 
-      <Stack spacing="8px">
+      <DialogActions>
+        <Button variant="secondary" onClick={props.onBack}>
+          {t('tr_back')}
+        </Button>
         <Button
           variant="main"
           onClick={handleImportData}
@@ -266,10 +270,7 @@ const ConfirmImport = (props: ConfirmImportProps) => {
         >
           {t('tr_import')}
         </Button>
-        <Button variant="secondary" onClick={props.onBack}>
-          {t('tr_back')}
-        </Button>
-      </Stack>
+      </DialogActions>
     </Stack>
   );
 };

--- a/src/features/congregation/settings/import_export/export/index.tsx
+++ b/src/features/congregation/settings/import_export/export/index.tsx
@@ -5,6 +5,7 @@ import { useAppTranslation } from '@hooks/index';
 import { ExportType } from './index.types';
 import useExport from './useExport';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 
 const Export = (props: ExportType) => {
@@ -28,14 +29,7 @@ const Export = (props: ExportType) => {
         </Box>
       </Stack>
 
-      <Stack spacing="8px">
-        <Button
-          variant="main"
-          onClick={handleDownload}
-          endIcon={isProcessing && <IconLoading />}
-        >
-          {t('tr_download')}
-        </Button>
+      <DialogActions>
         <Button
           variant="secondary"
           disabled={isProcessing}
@@ -43,7 +37,14 @@ const Export = (props: ExportType) => {
         >
           {t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button
+          variant="main"
+          onClick={handleDownload}
+          endIcon={isProcessing && <IconLoading />}
+        >
+          {t('tr_download')}
+        </Button>
+      </DialogActions>
     </Stack>
   );
 };

--- a/src/features/congregation/settings/language_groups/group_add/group_details/index.tsx
+++ b/src/features/congregation/settings/language_groups/group_add/group_details/index.tsx
@@ -3,6 +3,7 @@ import { useAppTranslation } from '@hooks/index';
 import { GroupDetailsProps } from './index.types';
 import useGroupDetails from './useGroupDetails';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import LanguageGroupDetails from '../../group_details';
 
@@ -27,14 +28,14 @@ const GroupDetails = (props: GroupDetailsProps) => {
         onLanguageChange={handleLanguageChange}
       />
 
-      <Stack spacing="8px">
-        <Button variant="main" onClick={props.onAction}>
-          {t('tr_next')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button variant="main" onClick={props.onAction}>
+          {t('tr_next')}
+        </Button>
+      </DialogActions>
     </Stack>
   );
 };

--- a/src/features/congregation/settings/language_groups/group_add/group_members/index.tsx
+++ b/src/features/congregation/settings/language_groups/group_add/group_members/index.tsx
@@ -3,6 +3,7 @@ import { useAppTranslation } from '@hooks/index';
 import { GroupMembersProps } from './index.types';
 import useGroupMembers from './useGroupMembers';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import IconLoading from '@components/icon_loading';
 import Typography from '@components/typography';
 import LanguageGroupMembers from '../../group_members';
@@ -24,7 +25,10 @@ const GroupMembers = (props: GroupMembersProps) => {
         group={props.group}
       />
 
-      <Stack spacing="8px">
+      <DialogActions>
+        <Button variant="secondary" onClick={props.onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           onClick={handleCreateGroup}
@@ -32,10 +36,7 @@ const GroupMembers = (props: GroupMembersProps) => {
         >
           {t('tr_createGroup')}
         </Button>
-        <Button variant="secondary" onClick={props.onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Stack>
+      </DialogActions>
     </Stack>
   );
 };

--- a/src/features/congregation/settings/language_groups/group_delete/index.tsx
+++ b/src/features/congregation/settings/language_groups/group_delete/index.tsx
@@ -1,10 +1,10 @@
-import { Stack } from '@mui/material';
 import { IconDelete } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { GroupDeleteProps } from './index.types';
 import useGroupDelete from './useGroupDelete';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import IconButton from '@components/icon_button';
 import IconLoading from '@components/icon_loading';
 import Typography from '@components/typography';
@@ -34,7 +34,10 @@ const GroupDelete = (props: GroupDeleteProps) => {
         <Typography className="body-regular" color="var(--grey-400)">
           {t('tr_languageGroupDeleteDesc')}
         </Typography>
-        <Stack spacing="8px" width="100%">
+        <DialogActions>
+          <Button variant="secondary" onClick={handleClose}>
+            {t('tr_cancel')}
+          </Button>
           <Button
             variant="main"
             onClick={handleDelete}
@@ -43,10 +46,7 @@ const GroupDelete = (props: GroupDeleteProps) => {
           >
             {t('tr_delete')}
           </Button>
-          <Button variant="secondary" onClick={handleClose}>
-            {t('tr_cancel')}
-          </Button>
-        </Stack>
+        </DialogActions>
       </Dialog>
 
       <IconButton onClick={handleOpen} sx={{ padding: 0.2 }}>

--- a/src/features/congregation/settings/language_groups/group_info/index.tsx
+++ b/src/features/congregation/settings/language_groups/group_info/index.tsx
@@ -1,9 +1,10 @@
-import { Box, Stack } from '@mui/material';
+import { Box } from '@mui/material';
 import { useAppTranslation } from '@hooks/index';
 import { GroupInfoProps } from './index.types';
 import useGroupInfo from './useGroupInfo';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import IconLoading from '@components/icon_loading';
 import LanguageGroupMembers from '../group_members';
 import LanguageGroupDetails from '../group_details';
@@ -64,7 +65,10 @@ const GroupInfo = (props: GroupInfoProps) => {
         />
       </Box>
 
-      <Stack spacing="8px" width="100%">
+      <DialogActions>
+        <Button variant="secondary" onClick={handleClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           onClick={handleSaveChange}
@@ -72,10 +76,7 @@ const GroupInfo = (props: GroupInfoProps) => {
         >
           {t('tr_save')}
         </Button>
-        <Button variant="secondary" onClick={handleClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Stack>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/contact/index.tsx
+++ b/src/features/contact/index.tsx
@@ -5,6 +5,7 @@ import { useAppTranslation } from '@hooks/index';
 import useContact from './useContact';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import TextMarkup from '@components/text_markup';
 import Typography from '@components/typography';
 import TextField from '@components/textfield';
@@ -76,22 +77,7 @@ const Contact = () => {
         onChange={(e) => setMessage(e.target.value)}
       />
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'stretch',
-          gap: '8px',
-          alignSelf: 'stretch',
-        }}
-      >
-        <Button
-          variant="main"
-          onClick={handleSendMessage}
-          endIcon={isProcessing && <IconLoading />}
-        >
-          {t('tr_sendFeedback')}
-        </Button>
+      <DialogActions>
         <Button
           variant="secondary"
           disabled={isProcessing}
@@ -99,7 +85,14 @@ const Contact = () => {
         >
           {t('tr_cancel')}
         </Button>
-      </Box>
+        <Button
+          variant="main"
+          onClick={handleSendMessage}
+          endIcon={isProcessing && <IconLoading />}
+        >
+          {t('tr_sendFeedback')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/dashboard/initial_setup/basic_settings/index.tsx
+++ b/src/features/dashboard/initial_setup/basic_settings/index.tsx
@@ -3,6 +3,7 @@ import { useAppTranslation } from '@hooks/index';
 import { BasicSettingsProps } from './index.types';
 import useBasicSettings from './useBasicSettings';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import DateFormat from '@features/congregation/settings/meeting_forms/date_format';
 import DataSharing from '@features/congregation/settings/congregation_privacy/data_sharing';
 import HourFormat from '@features/congregation/settings/congregation_basic/hour_format';
@@ -30,14 +31,14 @@ const BasicSettings = (props: BasicSettingsProps) => {
         <NameFormat />
       </Stack>
 
-      <Stack spacing="8px">
-        <Button variant="main" onClick={handleSave}>
-          {t('tr_saveAndContinueBtn')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={props.onMove}>
           {t('tr_skipThisStepBtn')}
         </Button>
-      </Stack>
+        <Button variant="main" onClick={handleSave}>
+          {t('tr_saveAndContinueBtn')}
+        </Button>
+      </DialogActions>
     </Box>
   );
 };

--- a/src/features/dashboard/initial_setup/person_record/index.tsx
+++ b/src/features/dashboard/initial_setup/person_record/index.tsx
@@ -1,8 +1,9 @@
-import { Box, Stack } from '@mui/material';
+import { Box } from '@mui/material';
 import { useAppTranslation, useBreakpoints } from '@hooks/index';
 import { PersonRecordProps } from './index.types';
 import usePersonRecord from './usePersonRecord';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
 import IconLoading from '@components/icon_loading';
@@ -50,7 +51,14 @@ const PersonRecord = ({ onPrevious }: PersonRecordProps) => {
         />
       </Box>
 
-      <Stack spacing="8px">
+      <DialogActions>
+        <Button
+          variant="secondary"
+          disabled={isProcessing}
+          onClick={onPrevious}
+        >
+          {t('tr_back')}
+        </Button>
         <Button
           variant="main"
           onClick={handleSavePerson}
@@ -62,14 +70,7 @@ const PersonRecord = ({ onPrevious }: PersonRecordProps) => {
         >
           {t('tr_done')}
         </Button>
-        <Button
-          variant="secondary"
-          disabled={isProcessing}
-          onClick={onPrevious}
-        >
-          {t('tr_back')}
-        </Button>
-      </Stack>
+      </DialogActions>
     </Box>
   );
 };

--- a/src/features/demo/notice/index.tsx
+++ b/src/features/demo/notice/index.tsx
@@ -1,7 +1,7 @@
-import { Stack } from '@mui/material';
 import { useAppTranslation } from '@hooks/index';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import TextMarkup from '@components/text_markup';
 import Typography from '@components/typography';
 import useNotice from './useNotice';
@@ -21,19 +21,15 @@ const DemoNotice = () => {
         anchorClassName="h4"
       />
 
-      <Stack spacing="8px" width="100%">
-        <Button variant="main" onClick={handleClose} sx={{ width: '100%' }}>
-          {t('tr_testStart')}
-        </Button>
-
-        <Button
-          variant="secondary"
-          onClick={handleOpenRealApp}
-          sx={{ width: '100%' }}
-        >
+      <DialogActions>
+        <Button variant="secondary" onClick={handleOpenRealApp}>
           {t('tr_openRealApp')}
         </Button>
-      </Stack>
+
+        <Button variant="main" onClick={handleClose}>
+          {t('tr_testStart')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/meetings/assignments_delete/index.tsx
+++ b/src/features/meetings/assignments_delete/index.tsx
@@ -5,6 +5,7 @@ import { AssignmentsDeleteType } from './index.types';
 import useAssignmentsDelete from './useAssignmentsDelete';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import WeekRangeSelector from '../week_range_selector';
 
@@ -39,14 +40,10 @@ const AssignmentsDelete = ({
         onEndChange={handleSetEndWeek}
       />
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           disabled={isProcessing}
@@ -55,10 +52,7 @@ const AssignmentsDelete = ({
         >
           {t('tr_clearSelectedWeeks')}
         </Button>
-        <Button variant="secondary" onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/meetings/assignments_week_delete/index.tsx
+++ b/src/features/meetings/assignments_week_delete/index.tsx
@@ -5,6 +5,7 @@ import { useAppTranslation } from '@hooks/index';
 import useAssignmentsDelete from './useAssignmentsWeekDelete';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 
 const AssignmentsWeekDelete = ({
@@ -34,14 +35,10 @@ const AssignmentsWeekDelete = ({
         </Typography>
       </Box>
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           color="red"
@@ -51,10 +48,7 @@ const AssignmentsWeekDelete = ({
         >
           {t('tr_clear')}
         </Button>
-        <Button variant="secondary" onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/meetings/midweek_export/index.tsx
+++ b/src/features/meetings/midweek_export/index.tsx
@@ -6,6 +6,7 @@ import useMidweekExport from './useMidweekExport';
 import Button from '@components/button';
 import Checkbox from '@components/checkbox';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Tabs from '@components/tabs';
 import Typography from '@components/typography';
 import S89TemplateSelector from './S89TemplateSelector';
@@ -96,18 +97,17 @@ const MidweekExport = ({ open, onClose }: MidweekExportType) => {
         />
       </Box>
 
-      <Box
+      <DialogActions
         sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
           position: 'absolute',
           bottom: 0,
           right: 0,
           padding: '24px',
         }}
       >
+        <Button variant="secondary" onClick={onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           endIcon={isProcessing && <IconLoading />}
@@ -115,10 +115,7 @@ const MidweekExport = ({ open, onClose }: MidweekExportType) => {
         >
           {t('tr_export')}
         </Button>
-        <Button variant="secondary" onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/meetings/monthly_view/add_custom_modal_window/index.tsx
+++ b/src/features/meetings/monthly_view/add_custom_modal_window/index.tsx
@@ -1,4 +1,5 @@
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import { AddCustomModalWindowType } from './index.types';
 import { Box } from '@mui/material';
 import { useAppTranslation } from '@hooks/index';
@@ -58,23 +59,7 @@ const AddCustomModalWindow = (props: AddCustomModalWindowType) => {
           isOverwrite={true}
         />
       </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          width: '100%',
-          gap: '8px',
-        }}
-      >
-        <Button
-          variant="main"
-          onClick={() => {
-            handleAddCustomLCPart();
-            props.closeFunc();
-          }}
-        >
-          {t('tr_add')}
-        </Button>
+      <DialogActions>
         <Button
           variant="secondary"
           color="red"
@@ -85,7 +70,16 @@ const AddCustomModalWindow = (props: AddCustomModalWindowType) => {
         >
           {t('tr_delete')}
         </Button>
-      </Box>
+        <Button
+          variant="main"
+          onClick={() => {
+            handleAddCustomLCPart();
+            props.closeFunc();
+          }}
+        >
+          {t('tr_add')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/meetings/outgoing_talks/schedule_delete/index.tsx
+++ b/src/features/meetings/outgoing_talks/schedule_delete/index.tsx
@@ -5,6 +5,7 @@ import { ScheduleDeleteType } from './index.types';
 import useAssignmentsDelete from './useScheduleDelete';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 
 const ScheduleDelete = (props: ScheduleDeleteType) => {
@@ -21,14 +22,10 @@ const ScheduleDelete = (props: ScheduleDeleteType) => {
         </Typography>
       </Box>
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={props.onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           color="red"
@@ -38,10 +35,7 @@ const ScheduleDelete = (props: ScheduleDeleteType) => {
         >
           {t('tr_delete')}
         </Button>
-        <Button variant="secondary" onClick={props.onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/meetings/schedule_autofill/index.tsx
+++ b/src/features/meetings/schedule_autofill/index.tsx
@@ -5,6 +5,7 @@ import { ScheduleAutofillType } from './index.types';
 import useScheduleAutofill from './useScheduleAutofill';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import WeekRangeSelector from '../week_range_selector';
 
@@ -37,14 +38,10 @@ const ScheduleAutofillDialog = ({
         onEndChange={handleSetEndWeek}
       />
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           disabled={isProcessing}
@@ -53,10 +50,7 @@ const ScheduleAutofillDialog = ({
         >
           {t('tr_autofill')}
         </Button>
-        <Button variant="secondary" onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/meetings/schedule_publish/index.tsx
+++ b/src/features/meetings/schedule_publish/index.tsx
@@ -5,6 +5,7 @@ import { SchedulePublishProps } from './index.types';
 import useSchedulePublish from './useSchedulePublish';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Divider from '@components/divider';
 import Typography from '@components/typography';
 import YearContainer from './year_container';
@@ -45,14 +46,10 @@ const SchedulePublish = (props: SchedulePublishProps) => {
         ))}
       </Stack>
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={props.onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           disabled={isProcessing}
@@ -61,10 +58,7 @@ const SchedulePublish = (props: SchedulePublishProps) => {
         >
           {t('tr_publish')}
         </Button>
-        <Button variant="secondary" onClick={props.onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/meetings/weekend_editor/song_selector/index.tsx
+++ b/src/features/meetings/weekend_editor/song_selector/index.tsx
@@ -3,6 +3,7 @@ import { IconClose } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { SongSelectorProps } from './index.types';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import IconButton from '@components/icon_button';
 import Typography from '@components/typography';
 import useSongSelector from './useSongSelector';
@@ -73,14 +74,14 @@ const SongSelector = (props: SongSelectorProps) => {
           ))}
         </RadioGroup>
 
-        <Stack spacing="8px">
-          <Button variant="main" onClick={handleAddSong}>
-            {t('tr_addSong')}
-          </Button>
+        <DialogActions>
           <Button variant="secondary" onClick={handleClose}>
             {t('tr_skip')}
           </Button>
-        </Stack>
+          <Button variant="main" onClick={handleAddSong}>
+            {t('tr_addSong')}
+          </Button>
+        </DialogActions>
       </Stack>
     </Dialog>
   );

--- a/src/features/meetings/weekend_export/index.tsx
+++ b/src/features/meetings/weekend_export/index.tsx
@@ -5,6 +5,7 @@ import { WeekendExportType } from './index.types';
 import useWeekendExport from './useWeekendExport';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import WeekRangeSelector from '../week_range_selector';
 import Checkbox from '@components/checkbox';
@@ -70,14 +71,10 @@ const WeekendExport = ({ open, onClose }: WeekendExportType) => {
         />
       </Box>
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           disabled={isProcessing}
@@ -86,10 +83,7 @@ const WeekendExport = ({ open, onClose }: WeekendExportType) => {
         >
           {t('tr_export')}
         </Button>
-        <Button variant="secondary" onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/ministry/report/form_S4/bible_studies/editor/index.tsx
+++ b/src/features/ministry/report/form_S4/bible_studies/editor/index.tsx
@@ -1,10 +1,11 @@
-import { Box, Stack } from '@mui/material';
+import { Box } from '@mui/material';
 import { IconClose } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { BibleStudyEditorProps } from './index.types';
 import useBibleStudy from './useBibleStudy';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import IconButton from '@components/icon_button';
 import Typography from '@components/typography';
 import TextField from '@components/textfield';
@@ -42,10 +43,7 @@ const BibleStudyEditor = (props: BibleStudyEditorProps) => {
         onChange={(e) => handleChange(e.target.value)}
       />
 
-      <Stack spacing="8px">
-        <Button variant="main" onClick={handleSave}>
-          {props.bibleStudy ? t('tr_saveChanges') : t('tr_save')}
-        </Button>
+      <DialogActions>
         <Button
           variant="secondary"
           color="red"
@@ -53,7 +51,10 @@ const BibleStudyEditor = (props: BibleStudyEditorProps) => {
         >
           {props.bibleStudy ? t('tr_deleteStudy') : t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button variant="main" onClick={handleSave}>
+          {props.bibleStudy ? t('tr_saveChanges') : t('tr_save')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/ministry/report/form_S4/submit_report/index.tsx
+++ b/src/features/ministry/report/form_S4/submit_report/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from '@mui/material';
+import { Box } from '@mui/material';
 import { IconClose } from '@components/icons';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
@@ -6,6 +6,7 @@ import { SubmitReportProps } from './index.types';
 import useSubmitReport from './useSubmitReport';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import IconButton from '@components/icon_button';
 import Typography from '@components/typography';
 
@@ -49,7 +50,14 @@ const SubmitReport = (props: SubmitReportProps) => {
           : t('tr_extraTimeDesc')}
       </Typography>
 
-      <Stack spacing="8px" width="100%">
+      <DialogActions>
+        <Button
+          variant="secondary"
+          onClick={handleKeepMinutesOrClose}
+          disabled={isProcessing}
+        >
+          {minutes_remains === 0 ? t('tr_cancel') : t('tr_btnNoKeepIt')}
+        </Button>
         <Button
           variant="main"
           onClick={handleTransferAndSubmit}
@@ -58,14 +66,7 @@ const SubmitReport = (props: SubmitReportProps) => {
         >
           {minutes_remains === 0 ? t('tr_yes') : t('tr_btnTransfer')}
         </Button>
-        <Button
-          variant="secondary"
-          onClick={handleKeepMinutesOrClose}
-          disabled={isProcessing}
-        >
-          {minutes_remains === 0 ? t('tr_cancel') : t('tr_btnNoKeepIt')}
-        </Button>
-      </Stack>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/ministry/report/form_S4/withdraw_report/index.tsx
+++ b/src/features/ministry/report/form_S4/withdraw_report/index.tsx
@@ -1,10 +1,10 @@
-import { Stack } from '@mui/material';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
 import { WithdrawReportProps } from './index.types';
 import useWithdrawReport from './useWithdrawReport';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 
 const WithdrawReport = (props: WithdrawReportProps) => {
@@ -20,7 +20,14 @@ const WithdrawReport = (props: WithdrawReportProps) => {
         {t('tr_undoSubmissionDesc')}
       </Typography>
 
-      <Stack spacing="8px" width="100%">
+      <DialogActions>
+        <Button
+          variant="secondary"
+          onClick={props.onClose}
+          disabled={isProcessing}
+        >
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           onClick={handleWithdrawal}
@@ -29,14 +36,7 @@ const WithdrawReport = (props: WithdrawReportProps) => {
         >
           {t('tr_yes')}
         </Button>
-        <Button
-          variant="secondary"
-          onClick={props.onClose}
-          disabled={isProcessing}
-        >
-          {t('tr_cancel')}
-        </Button>
-      </Stack>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/ministry/report/ministry_timer/add_time_dialog/index.tsx
+++ b/src/features/ministry/report/ministry_timer/add_time_dialog/index.tsx
@@ -1,16 +1,15 @@
 import { Box } from '@mui/material';
-import { useAppTranslation, useBreakpoints } from '@hooks/index';
+import { useAppTranslation } from '@hooks/index';
 import { AddTimeDialogProps } from './index.types';
 import useAddTimeDialog from './useAddTimeDialog';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import TimePickerSlider from '@components/time_picker_slider';
 import Typography from '@components/typography';
 
 const AddTimeDialog = (props: AddTimeDialogProps) => {
   const { t } = useAppTranslation();
-
-  const { tabletUp } = useBreakpoints();
 
   const { handleAddTime, handleValueChange, value } = useAddTimeDialog(props);
 
@@ -37,22 +36,14 @@ const AddTimeDialog = (props: AddTimeDialogProps) => {
         <TimePickerSlider value={value} onChange={handleValueChange} />
       </Box>
 
-      <Box
-        sx={{
-          width: '100%',
-          display: 'flex',
-          flexDirection: tabletUp ? 'row' : 'column-reverse',
-          gap: '8px',
-          justifyContent: 'space-between',
-        }}
-      >
+      <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}
         </Button>
         <Button variant="main" onClick={handleAddTime}>
           {t('tr_add')}
         </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/ministry/report/report_form_dialog/bible_study/index.tsx
+++ b/src/features/ministry/report/report_form_dialog/bible_study/index.tsx
@@ -1,8 +1,9 @@
-import { Box, Stack } from '@mui/material';
+import { Box } from '@mui/material';
 import { IconClose } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import useBibleStudy from './useBibleStudy';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import IconButton from '@components/icon_button';
 import Typography from '@components/typography';
 import TextField from '@components/textfield';
@@ -43,10 +44,7 @@ const BibleStudy = () => {
 
       <TextField label={t('tr_name')} inputRef={nameRef} />
 
-      <Stack spacing="8px">
-        <Button variant="main" onClick={handleSave}>
-          {bibleStudy ? t('tr_saveChanges') : t('tr_save')}
-        </Button>
+      <DialogActions>
         <Button
           variant="secondary"
           color="red"
@@ -54,7 +52,10 @@ const BibleStudy = () => {
         >
           {bibleStudy ? t('tr_deleteStudy') : t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button variant="main" onClick={handleSave}>
+          {bibleStudy ? t('tr_saveChanges') : t('tr_save')}
+        </Button>
+      </DialogActions>
     </Box>
   );
 };

--- a/src/features/ministry/report/report_form_dialog/service_time/index.tsx
+++ b/src/features/ministry/report/report_form_dialog/service_time/index.tsx
@@ -8,6 +8,7 @@ import BibleStudiesList from './bible_studies_list';
 import BibleStudySelector from '../../bible_study_selector';
 import Button from '@components/button';
 import DatePicker from '@components/date_picker';
+import DialogActions from '@components/dialog_actions';
 import HoursCreditPresets from '../../hours_credit_presets';
 import HoursEditor from '@features/ministry/report/hours_editor';
 import StandardEditor from '@features/ministry/report/standard_editor';
@@ -153,14 +154,7 @@ const ServiceTime = (props: ServiceTimeProps) => {
         <BibleStudiesList />
       </FieldContainer>
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: tabletUp ? 'row' : 'column-reverse',
-          gap: '8px',
-          justifyContent: 'space-between',
-        }}
-      >
+      <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}
         </Button>
@@ -168,7 +162,7 @@ const ServiceTime = (props: ServiceTimeProps) => {
         <Button variant="main" onClick={handleSaveReport}>
           {isEdit ? t('tr_save') : t('tr_add')}
         </Button>
-      </Box>
+      </DialogActions>
     </Box>
   );
 };

--- a/src/features/my_profile/logout_confirm/index.tsx
+++ b/src/features/my_profile/logout_confirm/index.tsx
@@ -1,9 +1,9 @@
-import { Box } from '@mui/material';
 import { LogoutConfirmType } from './index.types';
 import { useAppTranslation } from '@hooks/index';
 import useLogoutConfirm from './useLogoutConfirm';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 
 const LogoutConfirm = ({ open, onClose }: LogoutConfirmType) => {
@@ -17,21 +17,14 @@ const LogoutConfirm = ({ open, onClose }: LogoutConfirmType) => {
       <Typography className="body-regular" color="var(--grey-400)">
         {t('tr_logoutClearDataDesc')}
       </Typography>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <Button variant="main" color="red" onClick={handleLogout}>
-          {t('tr_logOut')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}
         </Button>
-      </Box>
+        <Button variant="main" color="red" onClick={handleLogout}>
+          {t('tr_logOut')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/my_profile/security/delete_account/index.tsx
+++ b/src/features/my_profile/security/delete_account/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from '@mui/material';
+import { Stack } from '@mui/material';
 import { IconEncryptionKey } from '@components/icons';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
@@ -6,6 +6,7 @@ import { DeleteAccountProps } from './index.types';
 import useDeleteAccount from './useDeleteAccount';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
 import WaitingLoader from '@components/waiting_loader';
@@ -53,14 +54,15 @@ const DeleteAccount = ({ open, onClose }: DeleteAccountProps) => {
       )}
 
       {!isLoading && (
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '8px',
-            width: '100%',
-          }}
-        >
+        <DialogActions>
+          <Button
+            variant="secondary"
+            disabled={!isManageAccess ? isProcessing : false}
+            onClick={onClose}
+          >
+            {t('tr_cancel')}
+          </Button>
+
           {!isManageAccess && (
             <Button
               variant="main"
@@ -78,15 +80,7 @@ const DeleteAccount = ({ open, onClose }: DeleteAccountProps) => {
               {t('tr_manageAccess')}
             </Button>
           )}
-
-          <Button
-            variant="secondary"
-            disabled={!isManageAccess ? isProcessing : false}
-            onClick={onClose}
-          >
-            {t('tr_cancel')}
-          </Button>
-        </Box>
+        </DialogActions>
       )}
     </Dialog>
   );

--- a/src/features/my_profile/security/mfaDisable/index.tsx
+++ b/src/features/my_profile/security/mfaDisable/index.tsx
@@ -2,6 +2,7 @@ import { Box } from '@mui/material';
 import IconLoading from '@components/icon_loading';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import useMFADisable from './useMFADisable';
@@ -25,14 +26,10 @@ const MFADisable = ({ open, onClose }: MFADisableType) => {
         </Typography>
       </Box>
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
+      <DialogActions>
+        <Button variant="secondary" onClick={onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           color="red"
@@ -45,10 +42,7 @@ const MFADisable = ({ open, onClose }: MFADisableType) => {
         >
           {t('tr_disable')}
         </Button>
-        <Button variant="secondary" onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Box>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/my_profile/security/mfaEnable/index.tsx
+++ b/src/features/my_profile/security/mfaEnable/index.tsx
@@ -5,6 +5,7 @@ import { useAppTranslation } from '@hooks/index';
 import useMFAEnable from './useMFAEnable';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import OTPInput from '@components/otp_input';
 import Tabs from '@components/tabs';
 import TextField from '@components/textfield';
@@ -186,14 +187,10 @@ const MFAEnable = ({ open, onClose }: MFAEnableType) => {
             </Box>
           )}
 
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '8px',
-              width: '100%',
-            }}
-          >
+          <DialogActions>
+            <Button variant="secondary" onClick={onClose}>
+              {t('tr_cancel')}
+            </Button>
             <Button
               variant="main"
               disabled={userOTP.length < 6}
@@ -206,10 +203,7 @@ const MFAEnable = ({ open, onClose }: MFAEnableType) => {
             >
               {t('tr_verify')}
             </Button>
-            <Button variant="secondary" onClick={onClose}>
-              {t('tr_cancel')}
-            </Button>
-          </Box>
+          </DialogActions>
         </>
       )}
     </Dialog>

--- a/src/features/persons/disqualify/index.tsx
+++ b/src/features/persons/disqualify/index.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import { PersonDisqualifyConfirmType } from './index.types';
@@ -20,21 +21,14 @@ const PersonDisqualifyConfirm = ({
           {t('tr_markDisqualifiedDesc')}
         </Typography>
       </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <Button variant="main" onClick={onConfirm} color="red">
-          {t('tr_disqualify')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}
         </Button>
-      </Box>
+        <Button variant="main" onClick={onConfirm} color="red">
+          {t('tr_disqualify')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/persons/import_export/confirm_import/index.tsx
+++ b/src/features/persons/import_export/confirm_import/index.tsx
@@ -3,6 +3,7 @@ import Stack from '@mui/material/Stack';
 import IconImportCsv from '@components/icons/IconImportCsv';
 import Button from '@components/button';
 import Checkbox from '@components/checkbox';
+import DialogActions from '@components/dialog_actions';
 import Divider from '@components/divider';
 import IconLoading from '@components/icon_loading';
 import Typography from '@components/typography';
@@ -173,7 +174,10 @@ const ConfirmImport = (props: ConfirmImportProps) => {
         </Stack>
       </Stack>
 
-      <Stack spacing="8px">
+      <DialogActions>
+        <Button variant="secondary" onClick={props.onBack}>
+          {t('tr_back')}
+        </Button>
         <Button
           variant="main"
           onClick={handleImportData}
@@ -181,10 +185,7 @@ const ConfirmImport = (props: ConfirmImportProps) => {
         >
           {t('tr_import')}
         </Button>
-        <Button variant="secondary" onClick={props.onBack}>
-          {t('tr_back')}
-        </Button>
-      </Stack>
+      </DialogActions>
     </Stack>
   );
 };

--- a/src/features/persons/import_export/export/index.tsx
+++ b/src/features/persons/import_export/export/index.tsx
@@ -3,6 +3,7 @@ import Stack from '@mui/material/Stack';
 import { IconBackupOrganized } from '@components/icons';
 import IconLoading from '@components/icon_loading';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import useExportPersons from './useExportPersons';
@@ -29,14 +30,7 @@ const Export = (props: ExportType) => {
         </Box>
       </Stack>
 
-      <Stack spacing="8px">
-        <Button
-          variant="main"
-          onClick={handleExport}
-          endIcon={isProcessing && <IconLoading />}
-        >
-          {t('tr_download')}
-        </Button>
+      <DialogActions>
         <Button
           variant="secondary"
           disabled={isProcessing}
@@ -44,7 +38,14 @@ const Export = (props: ExportType) => {
         >
           {t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button
+          variant="main"
+          onClick={handleExport}
+          endIcon={isProcessing && <IconLoading />}
+        >
+          {t('tr_download')}
+        </Button>
+      </DialogActions>
     </Stack>
   );
 };

--- a/src/features/persons/list/person_delete/index.tsx
+++ b/src/features/persons/list/person_delete/index.tsx
@@ -1,6 +1,6 @@
-import { Box } from '@mui/material';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import { DeletePersonConfirmType } from './index.types';
@@ -18,21 +18,14 @@ const DeletePersonConfirm = ({
       <Typography className="body-regular" color="var(--grey-400)">
         {t('tr_deletePersonConfirmation')}
       </Typography>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <Button variant="main" onClick={onConfirm} color="red">
-          {t('tr_delete')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}
         </Button>
-      </Box>
+        <Button variant="main" onClick={onConfirm} color="red">
+          {t('tr_delete')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/persons/qualify/index.tsx
+++ b/src/features/persons/qualify/index.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import { PersonQualifyConfirmType } from './index.types';
@@ -20,21 +21,14 @@ const PersonQualifyConfirm = ({
           {t('tr_markQualifiedDesc')}
         </Typography>
       </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <Button variant="main" onClick={onConfirm}>
-          {t('tr_qualifyAgain')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}
         </Button>
-      </Box>
+        <Button variant="main" onClick={onConfirm}>
+          {t('tr_qualifyAgain')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/persons/speakers_catalog/my_congregation/congregations_access/index.tsx
+++ b/src/features/persons/speakers_catalog/my_congregation/congregations_access/index.tsx
@@ -4,6 +4,7 @@ import { useAppTranslation } from '@hooks/index';
 import useCongregationsAccess from './useCongregationsAccess';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import OutgoingSpeakersListActive from './active';
 import OutgoingSpeakersListInactive from './inactive';
 import TextMarkup from '@components/text_markup';
@@ -69,14 +70,14 @@ const OutgoingSpeakersAccess = ({ open, onClose }: CongregationAccessType) => {
             color="var(--grey-400)"
           />
 
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-            <Button variant="main" color="red" onClick={handleRevokeAccess}>
-              {t('tr_delete')}
-            </Button>
+          <DialogActions>
             <Button variant="secondary" onClick={() => handleSetDelete(null)}>
               {t('tr_cancel')}
             </Button>
-          </Box>
+            <Button variant="main" color="red" onClick={handleRevokeAccess}>
+              {t('tr_delete')}
+            </Button>
+          </DialogActions>
         </Box>
       )}
     </Dialog>

--- a/src/features/persons/speakers_catalog/my_congregation/visibility_toggle/visibility_off/index.tsx
+++ b/src/features/persons/speakers_catalog/my_congregation/visibility_toggle/visibility_off/index.tsx
@@ -3,6 +3,7 @@ import { VisibilityOffConfirmType } from './index.types';
 import { useAppTranslation } from '@hooks/index';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import TextMarkup from '@components/text_markup';
 import Typography from '@components/typography';
 
@@ -23,21 +24,14 @@ const VisibilityOffConfirm = ({
           content={t('tr_outgoingSpeakersHideDesc')}
         />
       </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <Button variant="main" onClick={onConfirm}>
-          {t('tr_hide')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}
         </Button>
-      </Box>
+        <Button variant="main" onClick={onConfirm}>
+          {t('tr_hide')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/persons/speakers_catalog/other_congregations/congregation_add/details/index.tsx
+++ b/src/features/persons/speakers_catalog/other_congregations/congregation_add/details/index.tsx
@@ -4,6 +4,7 @@ import { generateDateFromTime } from '@utils/date';
 import { useAppTranslation } from '@hooks/index';
 import Button from '@components/button';
 import ContactDetails from '../../contact_details';
+import DialogActions from '@components/dialog_actions';
 import MeetingTime from '../../meeting_time';
 import TextField from '@components/textfield';
 import Typography from '@components/typography';
@@ -75,21 +76,14 @@ const CongregationDetails = ({
         onPhoneChange={handleCoordinatorPhoneChange}
       />
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <Button variant="main" onClick={handleIncomingCongregationAdd}>
-          {t('tr_addCongregation')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={handleMovePrevious}>
           {t('tr_back')}
         </Button>
-      </Box>
+        <Button variant="main" onClick={handleIncomingCongregationAdd}>
+          {t('tr_addCongregation')}
+        </Button>
+      </DialogActions>
     </Box>
   );
 };

--- a/src/features/persons/speakers_catalog/other_congregations/congregation_add/index.tsx
+++ b/src/features/persons/speakers_catalog/other_congregations/congregation_add/index.tsx
@@ -7,6 +7,7 @@ import CongregationDetails from './details';
 import CongregationOfflineAdd from './offline';
 import CongregationOnlineAdd from './online';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Tabs from '@components/tabs';
 import Typography from '@components/typography';
 
@@ -78,14 +79,10 @@ const CongregationAdd = ({ onClose, open }: CongregationAddType) => {
             />
           </Box>
 
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '8px',
-              width: '100%',
-            }}
-          >
+          <DialogActions>
+            <Button variant="secondary" onClick={onClose}>
+              {t('tr_cancel')}
+            </Button>
             <Button
               variant="main"
               disabled={congregation === null}
@@ -93,10 +90,7 @@ const CongregationAdd = ({ onClose, open }: CongregationAddType) => {
             >
               {t('tr_continue')}
             </Button>
-            <Button variant="secondary" onClick={onClose}>
-              {t('tr_cancel')}
-            </Button>
-          </Box>
+          </DialogActions>
         </Box>
       )}
 

--- a/src/features/persons/speakers_catalog/speaker_details/talks_songs/index.tsx
+++ b/src/features/persons/speakers_catalog/speaker_details/talks_songs/index.tsx
@@ -3,6 +3,7 @@ import { useAppTranslation, useCurrentUser } from '@hooks/index';
 import { SpeakerTalksSongsType } from './index.types';
 import useTalksSongs from './useTalksSongs';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import SongsTalk from '../../songs_talk';
 
@@ -55,21 +56,14 @@ const SpeakerTalksSongs = ({ speaker, onClose }: SpeakerTalksSongsType) => {
       </Box>
 
       {isPublicTalkCoordinator && !cong_synced && (
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '8px',
-            width: '100%',
-          }}
-        >
-          <Button variant="main" onClick={handleToggleEdit}>
-            {isEdit ? t('tr_done') : t('tr_songsEdit')}
-          </Button>
+        <DialogActions>
           <Button variant="secondary" onClick={onClose}>
             {t('tr_cancel')}
           </Button>
-        </Box>
+          <Button variant="main" onClick={handleToggleEdit}>
+            {isEdit ? t('tr_done') : t('tr_songsEdit')}
+          </Button>
+        </DialogActions>
       )}
 
       {(!isPublicTalkCoordinator || cong_synced) && (

--- a/src/features/quick_settings/index.tsx
+++ b/src/features/quick_settings/index.tsx
@@ -2,6 +2,7 @@ import { Box } from '@mui/material';
 import { useAppTranslation } from '@hooks/index';
 import { QuickSettingsProps } from './index.types';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import Button from '@components/button';
 
@@ -26,21 +27,14 @@ const QuickSettings = ({
 
       {children}
 
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <Button variant="main" onClick={onClose}>
-          {t('tr_done')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}
         </Button>
-      </Box>
+        <Button variant="main" onClick={onClose}>
+          {t('tr_done')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/reports/branch_office/submit_report/index.tsx
+++ b/src/features/reports/branch_office/submit_report/index.tsx
@@ -4,6 +4,7 @@ import { SubmitReportProps } from './index.types';
 import useSubmitReport from './useSubmitReport';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 
 const SubmitReport = (props: SubmitReportProps) => {
@@ -21,14 +22,14 @@ const SubmitReport = (props: SubmitReportProps) => {
         </Typography>
       </Stack>
 
-      <Stack spacing="8px" width="100%">
-        <Button variant="main" onClick={handleSubmitted}>
-          {t('tr_markAsSubmitted')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button variant="main" onClick={handleSubmitted}>
+          {t('tr_markAsSubmitted')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/reports/branch_office/withdraw_report/index.tsx
+++ b/src/features/reports/branch_office/withdraw_report/index.tsx
@@ -4,6 +4,7 @@ import { WithdrawReportProps } from './index.types';
 import useSubmitReport from './useWithdrawReport';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 
 const WithdrawReport = (props: WithdrawReportProps) => {
@@ -21,14 +22,14 @@ const WithdrawReport = (props: WithdrawReportProps) => {
         </Typography>
       </Stack>
 
-      <Stack spacing="8px" width="100%">
-        <Button variant="main" onClick={handleWithdraw}>
-          {t('tr_undoSubmission')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button variant="main" onClick={handleWithdraw}>
+          {t('tr_undoSubmission')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/reports/publisher_records/export_S21/all_records/index.tsx
+++ b/src/features/reports/publisher_records/export_S21/all_records/index.tsx
@@ -5,6 +5,7 @@ import { AllRecordsProps } from './index.types';
 import { ExportType } from '../index.types';
 import useAllRecords from './useAllRecords';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import Radio from '@components/radio';
 import Typography from '@components/typography';
 
@@ -42,7 +43,10 @@ const AllRecords = (props: AllRecordsProps) => {
         />
       </RadioGroup>
 
-      <Stack spacing="8px" width="100%">
+      <DialogActions>
+        <Button variant="secondary" disabled={isProcessing} onClick={onClose}>
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           onClick={handleExport}
@@ -51,10 +55,7 @@ const AllRecords = (props: AllRecordsProps) => {
         >
           {type === 'all' ? t('tr_export') : t('tr_next')}
         </Button>
-        <Button variant="secondary" disabled={isProcessing} onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Stack>
+      </DialogActions>
     </>
   );
 };

--- a/src/features/reports/publisher_records/export_S21/specific_records/active_publishers/index.tsx
+++ b/src/features/reports/publisher_records/export_S21/specific_records/active_publishers/index.tsx
@@ -4,6 +4,7 @@ import { useAppTranslation } from '@hooks/index';
 import { ActivePublishersProps } from './index.types';
 import useActivePublishers from './useActivePublishers';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import SearchBar from '@components/search_bar';
 import RichTreeViewCheckboxes from '@components/rich_tree_view/checkboxes';
 
@@ -37,7 +38,14 @@ const ActivePublishers = (props: ActivePublishersProps) => {
         />
       </Stack>
 
-      <Stack spacing="8px" width="100%">
+      <DialogActions>
+        <Button
+          variant="secondary"
+          disabled={isProcessing}
+          onClick={props.onClose}
+        >
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           onClick={handleExport}
@@ -46,14 +54,7 @@ const ActivePublishers = (props: ActivePublishersProps) => {
         >
           {btnLabel}
         </Button>
-        <Button
-          variant="secondary"
-          disabled={isProcessing}
-          onClick={props.onClose}
-        >
-          {t('tr_cancel')}
-        </Button>
-      </Stack>
+      </DialogActions>
     </Stack>
   );
 };

--- a/src/features/reports/publisher_records/export_S21/specific_records/field_service_groups/index.tsx
+++ b/src/features/reports/publisher_records/export_S21/specific_records/field_service_groups/index.tsx
@@ -4,6 +4,7 @@ import { useAppTranslation } from '@hooks/index';
 import { FieldServiceGroupsProps } from './index.types';
 import useFieldServiceGroups from './useFieldServiceGroups';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import RichTreeViewCheckboxes from '@components/rich_tree_view/checkboxes';
 import SearchBar from '@components/search_bar';
 
@@ -37,7 +38,14 @@ const FieldServiceGroups = (props: FieldServiceGroupsProps) => {
         />
       </Stack>
 
-      <Stack spacing="8px" width="100%">
+      <DialogActions>
+        <Button
+          variant="secondary"
+          disabled={isProcessing}
+          onClick={props.onClose}
+        >
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           disabled={isProcessing}
@@ -46,14 +54,7 @@ const FieldServiceGroups = (props: FieldServiceGroupsProps) => {
         >
           {btnLabel}
         </Button>
-        <Button
-          variant="secondary"
-          disabled={isProcessing}
-          onClick={props.onClose}
-        >
-          {t('tr_cancel')}
-        </Button>
-      </Stack>
+      </DialogActions>
     </Stack>
   );
 };

--- a/src/features/reports/publisher_records/export_S21/specific_records/inactive_publishers/index.tsx
+++ b/src/features/reports/publisher_records/export_S21/specific_records/inactive_publishers/index.tsx
@@ -4,6 +4,7 @@ import { useAppTranslation } from '@hooks/index';
 import { InactivePublishersProps } from './index.types';
 import useActivePublishers from './useInactivePublishers';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 import SearchBar from '@components/search_bar';
 import RichTreeViewCheckboxes from '@components/rich_tree_view/checkboxes';
 
@@ -41,7 +42,14 @@ const InactivePublishers = (props: InactivePublishersProps) => {
         />
       </Stack>
 
-      <Stack spacing="8px" width="100%">
+      <DialogActions>
+        <Button
+          variant="secondary"
+          disabled={isProcessing}
+          onClick={props.onClose}
+        >
+          {t('tr_cancel')}
+        </Button>
         <Button
           variant="main"
           disabled={isProcessing}
@@ -50,14 +58,7 @@ const InactivePublishers = (props: InactivePublishersProps) => {
         >
           {btnLabel}
         </Button>
-        <Button
-          variant="secondary"
-          disabled={isProcessing}
-          onClick={props.onClose}
-        >
-          {t('tr_cancel')}
-        </Button>
-      </Stack>
+      </DialogActions>
     </Stack>
   );
 };

--- a/src/features/reports/publisher_records_details/report_details/index.tsx
+++ b/src/features/reports/publisher_records_details/report_details/index.tsx
@@ -6,6 +6,7 @@ import BibleStudies from './bible_studies';
 import Comments from './comments';
 import CreditField from './credit_field';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Divider from '@components/divider';
 import Button from '@components/button';
 import HoursField from './hours_field';
@@ -55,7 +56,7 @@ const ReportDetails = (props: ReportDetailsProps) => {
 
       <Comments />
 
-      <Stack spacing="8px" width="100%">
+      <DialogActions>
         {enable_quick_AP && (
           <Button
             variant="tertiary"
@@ -66,13 +67,13 @@ const ReportDetails = (props: ReportDetailsProps) => {
           </Button>
         )}
 
-        <Button variant="main" onClick={handleSaveReport}>
-          {t('tr_save')}
-        </Button>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}
         </Button>
-      </Stack>
+        <Button variant="main" onClick={handleSaveReport}>
+          {t('tr_save')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/theme_switcher/themeChangeConfirm/index.tsx
+++ b/src/features/theme_switcher/themeChangeConfirm/index.tsx
@@ -1,6 +1,6 @@
-import { Box } from '@mui/material';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
+import DialogActions from '@components/dialog_actions';
 import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import { ThemeChangeConfirmType } from './index.types';
@@ -18,21 +18,14 @@ const ThemeChangeConfirm = ({
       <Typography className="body-regular" color="var(--grey-400)">
         {t('tr_themeFollowOSDisableDesc')}
       </Typography>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <Button variant="main" onClick={onConfirm}>
-          {t('tr_yes')}
-        </Button>
+      <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}
         </Button>
-      </Box>
+        <Button variant="main" onClick={onConfirm}>
+          {t('tr_yes')}
+        </Button>
+      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/whats_new/buttons_action/index.tsx
+++ b/src/features/whats_new/buttons_action/index.tsx
@@ -1,7 +1,7 @@
-import { Stack } from '@mui/material';
 import { useAppTranslation } from '@hooks/index';
 import { ButtonsActionProps } from './index.types';
 import Button from '@components/button';
+import DialogActions from '@components/dialog_actions';
 
 const ButtonsAction = ({
   slides,
@@ -13,25 +13,23 @@ const ButtonsAction = ({
   const { t } = useAppTranslation();
 
   return (
-    <Stack spacing="8px" width="100%">
+    <DialogActions>
+      {slides.length > 1 && current > 0 && (
+        <Button variant="secondary" onClick={onBack}>
+          {t('tr_back')}
+        </Button>
+      )}
+
+      {slides.length > 1 && current === 0 && (
+        <Button variant="secondary" onClick={onClose}>
+          {t('tr_skip')}
+        </Button>
+      )}
+
       {slides.length > 1 && (
-        <>
-          <Button variant="main" onClick={onNext}>
-            {current === slides.length - 1 ? t('tr_ok') : t('tr_next')}
-          </Button>
-
-          {current > 0 && (
-            <Button variant="secondary" onClick={onBack}>
-              {t('tr_back')}
-            </Button>
-          )}
-
-          {current === 0 && (
-            <Button variant="secondary" onClick={onClose}>
-              {t('tr_skip')}
-            </Button>
-          )}
-        </>
+        <Button variant="main" onClick={onNext}>
+          {current === slides.length - 1 ? t('tr_ok') : t('tr_next')}
+        </Button>
       )}
 
       {slides.length <= 1 && (
@@ -39,7 +37,7 @@ const ButtonsAction = ({
           {t('tr_ok')}
         </Button>
       )}
-    </Stack>
+    </DialogActions>
   );
 };
 

--- a/src/global/index.css
+++ b/src/global/index.css
@@ -9,6 +9,15 @@ html {
   }
 }
 
+:root {
+  --accent-gradient-top: color-mix(in oklch, var(--accent-main), white 15%);
+  --btn-hover-overlay: rgba(var(--accent-dark-overlay-base), 0.22);
+}
+
+[data-theme='blue-light'] {
+  --accent-gradient-top: rgb(84, 110, 237);
+}
+
 body {
   background-color: var(--accent-100) !important;
   margin: 0;


### PR DESCRIPTION
# Description

Refreshes the shared action buttons and unifies how dialog/popup action buttons are laid out across the app.

**Buttons**

- Redesigns the main button as a gradient fill (a brighter top easing down to `--accent-main`) with a white top-lit border, driven by a new theme-aware `--accent-gradient-top` token — an exact value for the default theme and an adaptive fallback for the others. Colored main buttons derive their own brighter top.
- Hover keeps the rest colors and fades in a theme-aware darken overlay (`--btn-hover-overlay`, near-black in light themes, a softer dark-grey in dark themes); press adds a subtle scale-in. Colored main buttons keep their exact color on click (no dim).
- Adds the same press animation to the secondary and outline (tertiary) variants.

**Dialog action buttons**

- Adds a shared `DialogActions` component that standardizes the footer layout: on desktop the buttons form a single spaced row (secondary on the left, main on the right) with a stable minimum width; on mobile they stack full-width with the main button on top.
- Migrates ~60 dialogs and popups (confirmations, deletions, exports, setup wizards, the welcome and what's-new popups, etc.) to the shared component.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
