### PR TITLE
tweak(ui): uniform 10x10 pagination dots

### DIFF
--- a/src/features/app_start/shared/illustration/index.tsx
+++ b/src/features/app_start/shared/illustration/index.tsx
@@ -91,7 +91,7 @@ const StartupIllustration = () => {
               opacity: currentImage === index ? 1 : 0.48,
               padding: 0,
               margin: 0,
-              width: { mobile: '12px', laptop: '16px' },
+              width: '10px',
             }}
             onClick={() => handleSlide(index)}
           >

--- a/src/features/app_start/shared/illustration/useIllustration.tsx
+++ b/src/features/app_start/shared/illustration/useIllustration.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useRef, useState } from 'react';
-import { useMediaQuery, useTheme } from '@mui/material';
 import { SwiperRef } from 'swiper/react';
 import { useAppTranslation } from '@hooks/index';
 
@@ -13,22 +12,14 @@ import IllustrationOtherSchedules from '@components/illustrations/IllustrationOt
 const useIllustration = () => {
   const { t } = useAppTranslation();
 
-  const theme = useTheme();
   const swiperRef = useRef<SwiperRef>();
 
-  const laptopUp = useMediaQuery(theme.breakpoints.up('laptop'), {
-    noSsr: true,
-  });
 
   const [currentImage, setCurrentImage] = useState(0);
 
   const dotSize = useMemo(() => {
-    if (laptopUp) {
-      return { active: 16, inactive: 12 };
-    }
-
-    return { active: 12, inactive: 8 };
-  }, [laptopUp]);
+    return { active: 10, inactive: 10 };
+  }, []);
 
   const slides = useMemo(() => {
     return [

--- a/src/features/whats_new/image_viewer/index.tsx
+++ b/src/features/whats_new/image_viewer/index.tsx
@@ -90,8 +90,8 @@ const ImageViewer = ({
             <Box
               key={item.tr_title}
               sx={{
-                width: '12px',
-                height: '12px',
+                width: '10px',
+                height: '10px',
                 borderRadius: '50%',
                 backgroundColor:
                   current === index


### PR DESCRIPTION
# Description

Uniformly sets the pagination dots size to 10x10 across the application. This applies to both the start page illustrations and the "What's New" image viewer. The previous behavior where dot sizes varied across breakpoints and sections has been unified for consistency.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
