### PR TITLE
tweak(ui): quick settings hover animation

### DIFF
--- a/src/layouts/navbar/index.tsx
+++ b/src/layouts/navbar/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   AppBar,
   Box,
@@ -59,6 +60,8 @@ const menuStyle = {
 const NavBar = ({ isSupported }: NavBarType) => {
   const { t } = useAppTranslation();
   const theme = useTheme();
+
+  const [settingsAnimating, setSettingsAnimating] = useState(false);
 
   const { isAuthenticated } = useFirebaseAuth();
 
@@ -504,13 +507,28 @@ const NavBar = ({ isSupported }: NavBarType) => {
                   </Box>
                   {navBarOptions.quickSettings ? (
                     <IconButton
-                      onClick={handleQuickSettings}
+                      onClick={(e) => {
+                        handleQuickSettings(e);
+                        setSettingsAnimating(true);
+                        setTimeout(() => setSettingsAnimating(false), 250);
+                      }}
                       aria-label={t('tr_quickSettings')}
                       sx={{
                         marginRight: '-8px',
                         transition: 'background-color 50ms ease-in-out',
                         '&:hover': {
                           backgroundColor: 'var(--accent-200)',
+                          '& svg': {
+                            transform: settingsAnimating
+                              ? 'rotate(0deg)'
+                              : 'rotate(60deg)',
+                          },
+                        },
+                        '& svg': {
+                          transition: 'transform 0.25s ease-out',
+                          ...(settingsAnimating && {
+                            transform: 'rotate(0deg)',
+                          }),
                         },
                       }}
                     >


### PR DESCRIPTION
# Description

Adds a 60-degree clockwise rotation on hover for the quick settings icon, and implements a state-based snap-back on click to smoothly animate the icon back to 0 degrees without triggering CSS `:hover`/`:active` state conflicts.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
