### PR TITLE
tweak(ui): make body text smaller on desktop

### DIFF
--- a/src/global/global.css
+++ b/src/global/global.css
@@ -719,7 +719,7 @@
     font-weight: 400;
     font-style: normal;
     font-stretch: normal;
-    letter-spacing: -0.15px;
+    letter-spacing: 0px;
     line-height: 20px;
     text-indent: 0px;
     text-transform: none;
@@ -731,7 +731,7 @@
     font-weight: 450;
     font-style: normal;
     font-stretch: normal;
-    letter-spacing: 0.065px;
+    letter-spacing: 0px;
     line-height: 16px;
     text-indent: 0px;
     text-transform: none;
@@ -743,7 +743,7 @@
     font-weight: 400;
     font-style: normal;
     font-stretch: normal;
-    letter-spacing: 0.065px;
+    letter-spacing: 0px;
     line-height: 16px;
     text-indent: 0px;
     text-transform: none;
@@ -801,7 +801,7 @@
   }
 
   .h4 {
-    font-size: 16px;
+    font-size: 15px;
     text-decoration: none;
     font-weight: 500;
     font-style: normal;
@@ -825,7 +825,7 @@
   }
 
   .body-regular {
-    font-size: 16px;
+    font-size: 15px;
     text-decoration: none;
     font-weight: 400;
     font-style: normal;
@@ -839,7 +839,7 @@
   .body-small-semibold {
     font-size: 14px;
     text-decoration: none;
-    font-weight: 520;
+    font-weight: 500;
     font-style: normal;
     font-stretch: normal;
     letter-spacing: 0px;
@@ -854,7 +854,7 @@
     font-weight: 400;
     font-style: normal;
     font-stretch: normal;
-    letter-spacing: -0.28px;
+    letter-spacing: 0px;
     line-height: 18px;
     text-indent: 0px;
     text-transform: none;

--- a/src/global/global.css
+++ b/src/global/global.css
@@ -719,7 +719,7 @@
     font-weight: 400;
     font-style: normal;
     font-stretch: normal;
-    letter-spacing: 0px;
+    letter-spacing: -0.15px;
     line-height: 20px;
     text-indent: 0px;
     text-transform: none;
@@ -731,7 +731,7 @@
     font-weight: 450;
     font-style: normal;
     font-stretch: normal;
-    letter-spacing: 0px;
+    letter-spacing: 0.065px;
     line-height: 16px;
     text-indent: 0px;
     text-transform: none;
@@ -743,7 +743,7 @@
     font-weight: 400;
     font-style: normal;
     font-stretch: normal;
-    letter-spacing: 0px;
+    letter-spacing: 0.065px;
     line-height: 16px;
     text-indent: 0px;
     text-transform: none;
@@ -839,7 +839,7 @@
   .body-small-semibold {
     font-size: 14px;
     text-decoration: none;
-    font-weight: 500;
+    font-weight: 520;
     font-style: normal;
     font-stretch: normal;
     letter-spacing: 0px;
@@ -854,7 +854,7 @@
     font-weight: 400;
     font-style: normal;
     font-stretch: normal;
-    letter-spacing: 0px;
+    letter-spacing: -0.28px;
     line-height: 18px;
     text-indent: 0px;
     text-transform: none;


### PR DESCRIPTION
# Description

Reduces desktop body text sizes for improved visual consistency with the mobile layout.

Changes in `src/global/global.css` (desktop `@media (min-width: 768px)`):
- `.body-regular`: 16px → 15px (now matches mobile)
- `.h4`: 16px → 15px

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules