### PR TITLE
fix(meetings): show visiting speakers and congregation to users seeing only published schedules

### DIFF
--- a/src/definition/schedules.ts
+++ b/src/definition/schedules.ts
@@ -5,6 +5,8 @@ export type S140TemplateType = 'S140_default' | 'S140_app_normal';
 
 export type S89TemplateType = 'S89_1x1' | 'S89_4x1';
 
+// name and cong_name are stored when publishing: users without access to the
+// persons and speakers data can only display those
 export type AssignmentCongregation = {
   type: string;
   name: string;
@@ -13,6 +15,7 @@ export type AssignmentCongregation = {
   solo?: boolean;
   id?: string;
   _deleted?: true;
+  cong_name?: string;
 };
 
 export type WeekTypeCongregation = {

--- a/src/features/meetings/schedule_publish/useSchedulePublish.tsx
+++ b/src/features/meetings/schedule_publish/useSchedulePublish.tsx
@@ -364,6 +364,7 @@ const useSchedulePublish = ({ type, onClose }: SchedulePublishProps) => {
         const sourcesRemote = data.sources;
         const schedulesRemote = data.schedules;
 
+        // clone before the merge below: it mutates the matched remote records
         const schedulesPublished = structuredClone(schedulesRemote);
 
         const sourcesPublish = handleUpdateMaterialsFromRemote(

--- a/src/features/meetings/schedule_publish/useSchedulePublish.tsx
+++ b/src/features/meetings/schedule_publish/useSchedulePublish.tsx
@@ -18,7 +18,7 @@ import {
   SchedWeekType,
 } from '@definition/schedules';
 import { incomingSpeakersState } from '@states/visiting_speakers';
-import { speakerGetDisplayName, updateObject } from '@utils/common';
+import { schedulesStampVisitingSpeakers, updateObject } from '@utils/common';
 import {
   congIDState,
   displayNameMeetingsEnableState,
@@ -209,36 +209,19 @@ const useSchedulePublish = ({ type, onClose }: SchedulePublishProps) => {
     return finalData;
   };
 
-  const handleUpdateSchedules = (schedules: SchedWeekType[]) => {
+  const handleUpdateSchedules = (
+    schedules: SchedWeekType[],
+    published: SchedWeekType[]
+  ) => {
     if (type === 'midweek') return schedules;
 
-    const newSchedules = structuredClone(schedules);
-
-    return newSchedules.map((schedule) => {
-      if (!schedule.weekend_meeting) return schedule;
-
-      for (const speakerSchedule of schedule.weekend_meeting.speaker.part_1) {
-        const talkType = schedule.weekend_meeting.public_talk_type.find(
-          (record) => record.type
-        )?.value;
-
-        if (speakerSchedule.value.length > 0) {
-          if (talkType === 'visitingSpeaker') {
-            const speaker = incomingSpeakers.find(
-              (record) => record.person_uid === speakerSchedule.value
-            );
-            speakerSchedule.name = !speaker
-              ? ''
-              : speakerGetDisplayName(
-                  speaker,
-                  displayNameEnabled,
-                  fullnameOption
-                );
-          }
-        }
-      }
-
-      return schedule;
+    return schedulesStampVisitingSpeakers({
+      schedules: structuredClone(schedules),
+      speakers: incomingSpeakers,
+      congregations,
+      displayNameEnabled,
+      fullnameOption,
+      published,
     });
   };
 
@@ -381,6 +364,8 @@ const useSchedulePublish = ({ type, onClose }: SchedulePublishProps) => {
         const sourcesRemote = data.sources;
         const schedulesRemote = data.schedules;
 
+        const schedulesPublished = structuredClone(schedulesRemote);
+
         const sourcesPublish = handleUpdateMaterialsFromRemote(
           sourcesLocalPublish,
           sourcesRemote
@@ -391,7 +376,10 @@ const useSchedulePublish = ({ type, onClose }: SchedulePublishProps) => {
           schedulesRemote
         );
 
-        const schedulesPrePublish = handleUpdateSchedules(schedulesBasePublish);
+        const schedulesPrePublish = handleUpdateSchedules(
+          schedulesBasePublish,
+          schedulesPublished
+        );
         let schedulesPublish = schedulesPrePublish;
 
         let talksPublish: OutgoingTalkExportScheduleType[] = undefined;

--- a/src/features/meetings/weekly_schedules/person_component/usePersonComponent.tsx
+++ b/src/features/meetings/weekly_schedules/person_component/usePersonComponent.tsx
@@ -14,8 +14,9 @@ import {
 } from '@states/settings';
 import { AssignmentCongregation } from '@definition/schedules';
 import { personsState } from '@states/persons';
-import { personGetDisplayName, speakerGetDisplayName } from '@utils/common';
+import { personGetDisplayName, speakerGetDetails } from '@utils/common';
 import { incomingSpeakersState } from '@states/visiting_speakers';
+import { speakersCongregationsState } from '@states/speakers_congregations';
 
 const usePersonComponent = ({
   week,
@@ -31,6 +32,7 @@ const usePersonComponent = ({
   const coDisplayName = useAtomValue(CODisplayNameState);
   const coFullname = useAtomValue(COFullnameState);
   const incomingSpeakers = useAtomValue(incomingSpeakersState);
+  const congregations = useAtomValue(speakersCongregationsState);
   const settings = useAtomValue(settingsState);
 
   const mmAuxCounselorDefaultEnabled = useMemo(() => {
@@ -108,20 +110,16 @@ const usePersonComponent = ({
         assignment === 'WM_Speaker_Part1' &&
         talkType?.value === 'visitingSpeaker'
       ) {
-        const speaker = incomingSpeakers.find(
-          (record) => record.person_uid === assigned?.value
-        );
+        const { name } = speakerGetDetails({
+          assigned,
+          speakers: incomingSpeakers,
+          congregations,
+          displayNameEnabled,
+          fullnameOption,
+        });
 
-        if (speaker) {
-          return {
-            name: speakerGetDisplayName(
-              speaker,
-              displayNameEnabled,
-              fullnameOption
-            ),
-            female: false,
-            active: false,
-          };
+        if (name.length > 0) {
+          return { name, female: false, active: false };
         }
       }
 
@@ -136,6 +134,12 @@ const usePersonComponent = ({
           fullnameOption
         );
         result.female = person.person_data.female.value;
+        result.active = assigned.value === userUID;
+      }
+
+      if (!person && assigned?.value?.length > 0 && assigned.name?.length > 0) {
+        result.name = assigned.name;
+        result.female = false;
         result.active = assigned.value === userUID;
       }
 
@@ -200,19 +204,25 @@ const usePersonComponent = ({
             result.female = false;
             result.active = assigned?.value === userUID;
           }
+
+          if (!person && assigned?.name?.length > 0) {
+            result.name = assigned.name;
+            result.female = false;
+            result.active = assigned.value === userUID;
+          }
         }
 
         if (talkType?.value === 'visitingSpeaker') {
-          const speaker = incomingSpeakers.find(
-            (record) => record.person_uid === assigned?.value
-          );
+          const { name } = speakerGetDetails({
+            assigned,
+            speakers: incomingSpeakers,
+            congregations,
+            displayNameEnabled,
+            fullnameOption,
+          });
 
-          if (speaker) {
-            result.name = speakerGetDisplayName(
-              speaker,
-              displayNameEnabled,
-              fullnameOption
-            );
+          if (name.length > 0) {
+            result.name = name;
             result.female = false;
             result.active = false;
           }
@@ -255,6 +265,7 @@ const usePersonComponent = ({
     coFullname,
     wsConductor,
     incomingSpeakers,
+    congregations,
     mmAuxCounselorDefaultEnabled,
     mmAuxCounselorDefault,
     schedule_id,

--- a/src/services/app/schedules.ts
+++ b/src/services/app/schedules.ts
@@ -90,7 +90,11 @@ import {
 import { applyAssignmentFilters, personIsAway, personIsElder } from './persons';
 import { personsByViewState } from '@states/persons';
 import { personsStateFind } from '@services/states/persons';
-import { buildPersonFullname, personGetDisplayName } from '@utils/common';
+import {
+  buildPersonFullname,
+  personGetDisplayName,
+  speakerGetDetails,
+} from '@utils/common';
 import { sourcesFind } from '@services/states/sources';
 import { weekTypeLocaleState } from '@states/weekType';
 import { VisitingSpeakerType } from '@definition/visiting_speakers';
@@ -816,11 +820,23 @@ export const schedulesWeekGetAssigned = ({
     }
 
     if (!person) {
-      result = assigned.value;
+      result = assigned.name?.length > 0 ? assigned.name : assigned.value;
     }
   }
 
   return result;
+};
+
+export const schedulesGetSpeakerDetails = (
+  assigned: AssignmentCongregation
+) => {
+  return speakerGetDetails({
+    assigned,
+    speakers: store.get(incomingSpeakersState),
+    congregations: store.get(speakersCongregationsState),
+    displayNameEnabled: store.get(displayNameMeetingsEnableState),
+    fullnameOption: store.get(fullnameOptionState),
+  });
 };
 
 export const schedulesGetHistoryDetails = ({
@@ -2815,16 +2831,11 @@ export const schedulesWeekendData = (
 ) => {
   const source = sourcesFind(schedule.weekOf);
   const talks = store.get(publicTalksState);
-  const speakers = store.get(incomingSpeakersState);
-
-  const congregations = store.get(speakersCongregationsState);
 
   const openingPrayerAuto = store.get(
     weekendMeetingOpeningPrayerAutoAssignState
   );
 
-  const fullnameOption = store.get(fullnameOptionState);
-  const useDisplayName = store.get(displayNameMeetingsEnableState);
   const defaultWTStudyConductor = store.get(defaultWTStudyConductorNameState);
   const lang = store.get(JWLangState);
   const congName = store.get(congNameState);
@@ -2956,31 +2967,18 @@ export const schedulesWeekendData = (
     )?.value;
 
     if (talkType === 'visitingSpeaker') {
-      const speaker = speakers.find(
-        (record) => record.person_uid === result.speaker_1_name
-      );
+      const assigned = schedulesGetData(
+        schedule,
+        ASSIGNMENT_PATH['WM_Speaker_Part1'],
+        dataView
+      ) as AssignmentCongregation;
 
-      result.speaker_1_name = '';
+      const { name, cong_name } = schedulesGetSpeakerDetails(assigned);
 
-      if (speaker) {
-        if (useDisplayName) {
-          result.speaker_1_name =
-            speaker.speaker_data.person_display_name.value;
-        }
+      result.speaker_1_name = name;
 
-        if (!useDisplayName) {
-          result.speaker_1_name = buildPersonFullname(
-            speaker.speaker_data.person_lastname.value,
-            speaker.speaker_data.person_firstname.value,
-            fullnameOption
-          );
-        }
-
-        const cong = congregations.find(
-          (record) => record.id === speaker.speaker_data.cong_id
-        );
-
-        result.speaker_cong_name = cong.cong_data.cong_name.value;
+      if (cong_name.length > 0) {
+        result.speaker_cong_name = cong_name;
       }
     }
 

--- a/src/services/app/schedules.ts
+++ b/src/services/app/schedules.ts
@@ -820,7 +820,7 @@ export const schedulesWeekGetAssigned = ({
     }
 
     if (!person) {
-      result = assigned.name?.length > 0 ? assigned.name : assigned.value;
+      result = assigned.solo ? assigned.value : assigned.name;
     }
   }
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,5 +1,7 @@
+import { AssignmentCongregation, SchedWeekType } from '@definition/schedules';
 import { PersonType } from '@definition/person';
 import { FullnameOption } from '@definition/settings';
+import { SpeakersCongregationsType } from '@definition/speakers_congregations';
 import { VisitingSpeakerType } from '@definition/visiting_speakers';
 
 export const convertStringToBoolean = (value) => {
@@ -223,6 +225,113 @@ export const speakerGetDisplayName = (
   }
 
   return result;
+};
+
+// visiting speakers are not synced to users without access to the speakers
+// catalog: they can only rely on the values stored when publishing
+export const speakerGetDetails = ({
+  assigned,
+  speakers,
+  congregations,
+  displayNameEnabled,
+  fullnameOption,
+}: {
+  assigned: AssignmentCongregation;
+  speakers: VisitingSpeakerType[];
+  congregations: SpeakersCongregationsType[];
+  displayNameEnabled: boolean;
+  fullnameOption: FullnameOption;
+}) => {
+  const result = { name: '', cong_name: '' };
+
+  if (!assigned?.value?.length) return result;
+
+  result.name = assigned.name ?? '';
+  result.cong_name = assigned.cong_name ?? '';
+
+  const speaker = speakers.find(
+    (record) => record.person_uid === assigned.value
+  );
+
+  if (!speaker) return result;
+
+  const name = speakerGetDisplayName(
+    speaker,
+    displayNameEnabled,
+    fullnameOption
+  );
+
+  if (name?.length > 0) {
+    result.name = name;
+  }
+
+  const congregation = congregations.find(
+    (record) => record.id === speaker.speaker_data.cong_id
+  );
+
+  const congName = congregation?.cong_data.cong_name.value ?? '';
+
+  if (congName.length > 0) {
+    result.cong_name = congName;
+  }
+
+  return result;
+};
+
+export const schedulesStampVisitingSpeakers = ({
+  schedules,
+  speakers,
+  congregations,
+  displayNameEnabled,
+  fullnameOption,
+  published = [],
+}: {
+  schedules: SchedWeekType[];
+  speakers: VisitingSpeakerType[];
+  congregations: SpeakersCongregationsType[];
+  displayNameEnabled: boolean;
+  fullnameOption: FullnameOption;
+  published?: SchedWeekType[];
+}) => {
+  for (const schedule of schedules) {
+    if (!schedule.weekend_meeting) continue;
+
+    const lastPublished = published.find(
+      (record) => record.weekOf === schedule.weekOf
+    );
+
+    for (const assigned of schedule.weekend_meeting.speaker.part_1) {
+      const talkType = schedule.weekend_meeting.public_talk_type.find(
+        (record) => record.type === assigned.type
+      )?.value;
+
+      if (talkType !== 'visitingSpeaker') continue;
+
+      // the merge with the remote schedules resets the stored values: the last
+      // publish is the fallback when the speaker cannot be resolved locally
+      const previous = lastPublished?.weekend_meeting?.speaker.part_1.find(
+        (record) =>
+          record.type === assigned.type && record.value === assigned.value
+      );
+
+      const { name, cong_name } = speakerGetDetails({
+        assigned: {
+          ...assigned,
+          name: assigned.name || previous?.name || '',
+          cong_name: assigned.cong_name || previous?.cong_name || '',
+        },
+        speakers,
+        congregations,
+        displayNameEnabled,
+        fullnameOption,
+      });
+
+      assigned.name = name;
+      assigned.cong_name = cong_name;
+    }
+  }
+
+  return schedules;
 };
 
 export const createNumbersArray = (length: number) => {


### PR DESCRIPTION
# Description

Visiting speakers were never displayed on published weekend schedules for users who only see the public meetings.

Published schedules identify the speaker with `person_uid` only, but the visiting speakers and their congregations are elder-only data: `dbGetMetadata` removes both tables for every other role, and they are encrypted with the master key. Those users can therefore never resolve the assignment, and the weekend meeting page as well as the weekend export were left blank.

The publish step already stored a display name on the assignment, but no reader ever used it, and the value was reset whenever the speaker could not be resolved by the publishing user.

Changes:

- store the speaker name and the congregation name on the assignment when publishing, keeping the values of the previous publish when the current user cannot resolve the speaker (the merge with the remote schedules resets them)
- use those values as a fallback in `speakerGetDetails`, shared by the weekend meeting page, the weekend export and the publish step
- resolve the talk type of the assignment data view instead of the first one, so language groups are handled correctly
- fall back to the stored name for any assignment that cannot be resolved locally, not only visiting speakers

`speaker_cong_name` is now filled the same way, so the congregation of the speaker is also visible on the weekend export.

Fixes #4643

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
