### PR TITLE
tweak(ui): add two columns layout for multiple-day upcoming events

### DIFF
--- a/src/features/activities/upcoming_events/upcoming_event/index.tsx
+++ b/src/features/activities/upcoming_events/upcoming_event/index.tsx
@@ -36,6 +36,7 @@ const UpcomingEvent = (props: UpcomingEventProps) => {
     handleMouseLeave,
     eventFormatted,
     previousDay,
+    dayColumns,
   } = useUpcomingEvent(props);
 
   if (isEdit) {
@@ -159,29 +160,46 @@ const UpcomingEvent = (props: UpcomingEventProps) => {
 
       {props.data.event_data.duration === UpcomingEventDuration.MultipleDays &&
         props.data.event_data.category !==
-          UpcomingEventCategory.SpecialCampaignWeek &&
-        eventFormatted.dates.map((eventDate, eventDateIndex) => (
-          <Fragment key={eventDate.date}>
-            <UpcomingEventDate
-              date={eventDate.dateFormatted}
-              day={eventDate.day}
-              title={t('tr_wholeDay')}
-              disabled={eventDate.date <= previousDay}
-              description={`${t('tr_day')} ${eventDateIndex + 1}/${eventFormatted.dates.length}`}
-              dayIndicatorRef={(element: HTMLDivElement) => {
-                dayIndicatorRefs.current[eventDateIndex] = element;
-              }}
-              dayIndicatorSharedWidth={dayIndicatorMaxWidth}
-            />
+          UpcomingEventCategory.SpecialCampaignWeek && (
+          <Box sx={{ display: 'flex', flexDirection: 'row', gap: '24px' }}>
+            {dayColumns.map((column, columnIndex) => (
+              <Box
+                key={column[0].date}
+                sx={{
+                  flex: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '16px',
+                  borderLeft:
+                    columnIndex > 0 ? '1px solid var(--accent-200)' : 'none',
+                  paddingLeft: columnIndex > 0 ? '24px' : 0,
+                }}
+              >
+                {column.map((eventDate, indexInColumn) => (
+                  <Fragment key={eventDate.date}>
+                    <UpcomingEventDate
+                      date={eventDate.dateFormatted}
+                      day={eventDate.day}
+                      title={t('tr_wholeDay')}
+                      disabled={eventDate.date <= previousDay}
+                      description={`${t('tr_day')} ${eventDate.index + 1}/${eventFormatted.dates.length}`}
+                      dayIndicatorRef={(element: HTMLDivElement) => {
+                        dayIndicatorRefs.current[eventDate.index] = element;
+                      }}
+                      dayIndicatorSharedWidth={dayIndicatorMaxWidth}
+                    />
 
-            {eventDateIndex + 1 !== eventFormatted.dates.length && (
-              <Divider color="var(--accent-200)" />
-            )}
-          </Fragment>
-        ))}
+                    {indexInColumn + 1 !== column.length && (
+                      <Divider color="var(--accent-200)" />
+                    )}
+                  </Fragment>
+                ))}
+              </Box>
+            ))}
+          </Box>
+        )}
     </Box>
   );
 };
 
 export default UpcomingEvent;
-

--- a/src/features/activities/upcoming_events/upcoming_event/useUpcomingEvent.tsx
+++ b/src/features/activities/upcoming_events/upcoming_event/useUpcomingEvent.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useBreakpoints } from '@hooks/index';
 import { IconError } from '@components/icons';
 import { dbUpcomingEventsSave } from '@services/dexie/upcoming_events';
 import { UpcomingEventType } from '@definition/upcoming_events';
@@ -10,6 +11,8 @@ import { decorationsForEvent } from '../decorations_for_event';
 import { UpcomingEventProps } from './index.types';
 
 const useUpcomingEvent = ({ data }: UpcomingEventProps) => {
+  const { tablet688Up } = useBreakpoints();
+
   const dayIndicatorRefs = useRef<HTMLDivElement[]>([]);
 
   const [isEdit, setIsEdit] = useState(false);
@@ -26,6 +29,21 @@ const useUpcomingEvent = ({ data }: UpcomingEventProps) => {
   const eventFormatted = useMemo(() => {
     return upcomingEventData(data);
   }, [data]);
+
+  const dayColumns = useMemo(() => {
+    const days = eventFormatted.dates.map((date, index) => ({
+      ...date,
+      index,
+    }));
+
+    if (!tablet688Up) return [days];
+
+    const splitIndex = Math.ceil(days.length / 2);
+
+    return [days.slice(0, splitIndex), days.slice(splitIndex)].filter(
+      (column) => column.length > 0
+    );
+  }, [eventFormatted.dates, tablet688Up]);
 
   const eventDecoration = useMemo(() => {
     const category = data.event_data.category;
@@ -67,7 +85,7 @@ const useUpcomingEvent = ({ data }: UpcomingEventProps) => {
     const widths = dayIndicatorRefs.current.map((el) => el?.offsetWidth || 0);
     const widest = Math.max(...widths);
     setDayIndicatorMaxWidth(widest);
-  }, []);
+  }, [dayColumns]);
 
   return {
     eventDecoration,
@@ -81,6 +99,7 @@ const useUpcomingEvent = ({ data }: UpcomingEventProps) => {
     handleMouseLeave,
     eventFormatted,
     previousDay,
+    dayColumns,
   };
 };
 

--- a/src/views/activities/upcoming_events/UpcomingEvent.tsx
+++ b/src/views/activities/upcoming_events/UpcomingEvent.tsx
@@ -1,5 +1,5 @@
 import { View, Text } from '@react-pdf/renderer';
-import { cloneElement } from 'react';
+import { cloneElement, Fragment } from 'react';
 import {
   UpcomingEventCategory,
   UpcomingEventDuration,
@@ -11,6 +11,14 @@ import UpcomingEventDate from './UpcomingEventDate';
 
 const UpcomingEvent = ({ event }: UpcomingEventProps) => {
   const { t } = useAppTranslation();
+
+  const days = event.dates.map((date, index) => ({ ...date, index }));
+
+  const splitIndex = Math.ceil(days.length / 2);
+
+  const dayColumns = [days.slice(0, splitIndex), days.slice(splitIndex)].filter(
+    (column) => column.length > 0
+  );
 
   return (
     <View
@@ -60,16 +68,42 @@ const UpcomingEvent = ({ event }: UpcomingEventProps) => {
         )}
 
         {event.duration === UpcomingEventDuration.MultipleDays &&
-          event.category !== UpcomingEventCategory.SpecialCampaignWeek &&
-          event.dates.map((eventDate, eventDateIndex) => (
-            <UpcomingEventDate
-              key={eventDate.date}
-              date={eventDate.dateFormatted}
-              day={eventDate.day}
-              title={t('tr_wholeDay')}
-              description={`${t('tr_day')} ${eventDateIndex + 1}/${event.dates.length}`}
-            />
-          ))}
+          event.category !== UpcomingEventCategory.SpecialCampaignWeek && (
+            <View style={{ flexDirection: 'row', gap: '12px' }}>
+              {dayColumns.map((column, columnIndex) => (
+                <View
+                  key={column[0].date}
+                  style={{
+                    flex: 1,
+                    flexDirection: 'column',
+                    gap: '10px',
+                    borderLeft: columnIndex > 0 ? '1px solid #E5E9F5' : 'none',
+                    paddingLeft: columnIndex > 0 ? '12px' : '0px',
+                  }}
+                >
+                  {column.map((eventDate, indexInColumn) => (
+                    <Fragment key={eventDate.date}>
+                      <UpcomingEventDate
+                        date={eventDate.dateFormatted}
+                        day={eventDate.day}
+                        title={t('tr_wholeDay')}
+                        description={`${t('tr_day')} ${eventDate.index + 1}/${event.dates.length}`}
+                      />
+
+                      {indexInColumn + 1 !== column.length && (
+                        <View
+                          style={{
+                            width: '100%',
+                            borderBottom: '1px solid #E5E9F5',
+                          }}
+                        />
+                      )}
+                    </Fragment>
+                  ))}
+                </View>
+              ))}
+            </View>
+          )}
 
         {event.category === UpcomingEventCategory.SpecialCampaignWeek && (
           <UpcomingEventDate


### PR DESCRIPTION
# Description

A multi-day event renders one row per day, so a six-day circuit overseer visit takes six full-width rows both on screen and in the exported PDF, while the space to the right of each date sits empty.

This lays those days out in two columns:

- days are split down the middle, and when the count is odd the extra day goes to the left column, so a 5-day event reads 3 left and 2 right
- day numbering continues down the left column and then down the right, so the labels stay in order
- the columns are separated by a vertical divider, and the divider between rows now runs inside each column rather than across both
- the PDF always uses two columns; the app uses them from large tablets up and keeps its previous single column on narrower screens

The date indicators share a width measured from the widest one. That measurement now runs again whenever the columns change, so an indicator sized for a full-width row does not keep that width once it sits in a half-width column.

## Note for reviewers

This touches the same day-list block as #5321. Whichever merges second will need a small conflict resolution in `views/activities/upcoming_events/UpcomingEvent.tsx` and `features/activities/upcoming_events/upcoming_event/`; the two changes are independent and do not overlap in intent.

Checked at 1280px and at 600px in the app, and in a generated PDF, with 3, 5 and 6 day events.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
