### PR TITLE
fix(auth): persist congregation id when onboarding resumes

### DIFF
--- a/src/features/app_start/vip/hooks/useAuth.tsx
+++ b/src/features/app_start/vip/hooks/useAuth.tsx
@@ -116,6 +116,17 @@ const useAuth = () => {
     }
 
     if (nextStep.createCongregation) {
+      // congregation exists remotely and onboarding resumes at the master key
+      // or access code step, so its id has to be stored for these endpoints
+      if (app_settings?.cong_settings) {
+        await dbAppSettingsUpdate({
+          'cong_settings.cong_id': app_settings.cong_settings.id,
+          'cong_settings.cong_name': app_settings.cong_settings.cong_name,
+          'cong_settings.country_code': app_settings.cong_settings.country_code,
+          'user_settings.cong_role': app_settings.user_settings.cong_role,
+        });
+      }
+
       setIsEmailAuth(false);
       setIsEmailSent(false);
       setIsUserSignIn(false);
@@ -168,8 +179,9 @@ const useAuth = () => {
         }
       }
 
+      // the local id defaults to an empty string, which `??` would keep
       const congID =
-        settings.cong_settings.cong_id ?? app_settings.cong_settings.id;
+        settings.cong_settings.cong_id || app_settings.cong_settings.id;
 
       await dbAppSettingsUpdate({
         'cong_settings.country_code': app_settings.cong_settings.country_code,

--- a/src/features/app_start/vip/startup/useStartup.tsx
+++ b/src/features/app_start/vip/startup/useStartup.tsx
@@ -30,6 +30,7 @@ import {
 import { APP_ROLES, VIP_ROLES } from '@constants/index';
 import { handleDeleteDatabase, loadApp, runUpdater } from '@services/app';
 import { apiValidateMe } from '@services/api/user';
+import { dbAppSettingsUpdate } from '@services/dexie/settings';
 import { userSignOut } from '@services/firebase/auth';
 import useFirebaseAuth from '@hooks/useFirebaseAuth';
 
@@ -147,6 +148,12 @@ const useStartup = () => {
         isAuthenticated &&
         (remoteMasterKey.length === 0 || remoteAccessCode.length === 0)
       ) {
+        if (congID.length === 0 && result.cong_id) {
+          await dbAppSettingsUpdate({
+            'cong_settings.cong_id': result.cong_id,
+          });
+        }
+
         if (masterKeyNeeded && remoteMasterKey.length === 0) {
           setCurrentStep(1);
           setIsLoading(false);

--- a/src/services/api/congregation.ts
+++ b/src/services/api/congregation.ts
@@ -137,6 +137,10 @@ export const apiSetCongregationMasterKey = async (key: string) => {
     idToken,
   } = await apiDefault();
 
+  if (congID.length === 0) {
+    throw new Error('error_app_generic-desc');
+  }
+
   const res = await fetch(
     `${apiHost}api/v3/congregations/admin/${congID}/master-key`,
     {
@@ -164,6 +168,10 @@ export const apiSetCongregationAccessCode = async (access_code: string) => {
     congID,
     idToken,
   } = await apiDefault();
+
+  if (congID.length === 0) {
+    throw new Error('error_app_generic-desc');
+  }
 
   const res = await fetch(
     `${apiHost}api/v3/congregations/admin/${congID}/access-code`,


### PR DESCRIPTION
# Description

When a congregation already exists on the server but its master key (or access code) was never set, sign-in skips step 1 of the congregation setup and goes straight to the master key step. The congregation id arrives in the login response, but it was never written to the local settings, so `congIDState` stayed empty and the request was sent to:

```
POST /api/v3/congregations/admin//master-key
```

The empty path parameter does not match the `:id` route, so the request ends in the invalid endpoint handler and returns 404. Onboarding cannot be completed on that device — every retry rebuilds the same URL. The access code step (step 3) fails the same way when it is the resumed step.

The local settings are emptied by normal actions: signing out ("Disconnect my account"), switching accounts, the app deleting the database itself (validation returns 404, congregation id mismatch, role change), or clearing browser data. A background `validate-me` call sometimes writes the congregation id afterwards, which is why the failure looks intermittent — it only succeeds if that response lands before the key is submitted.

Changes:

- `useAuth`: store congregation id, name, country code and roles when sign-in resumes onboarding at the master key or access code step.
- `useAuth`: use `||` instead of `??` when picking the congregation id, so a stored empty string does not win over the id from the server.
- `useStartup`: store the congregation id from the validation response before sending the user to the master key or access code step.
- `apiSetCongregationMasterKey` / `apiSetCongregationAccessCode`: fail with a clear error instead of sending a request with an empty id.

Verified against a local API (sws2apps-api on Firebase emulators): before the change the master key request returned 404 in every run, after the change it returns 200 and onboarding completes through the access code step.

Fixes #4831

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
