### PR TITLE
tweak(ui): improve mobile bottom buttons position, glow size and animate its width transition

### DIFF
--- a/src/global/index.css
+++ b/src/global/index.css
@@ -1,3 +1,10 @@
+:root {
+  --message-glow-small-offset-y: 4px;
+  --message-glow-small-blur: 12px;
+  --message-glow-small: 0px var(--message-glow-small-offset-y)
+    var(--message-glow-small-blur) 0px rgba(var(--accent-main-base), 0.24);
+}
+
 html {
   font-family: 'Inter', sans-serif;
   font-feature-settings: 'cv05';

--- a/src/layouts/bottom_menu/index.tsx
+++ b/src/layouts/bottom_menu/index.tsx
@@ -1,9 +1,16 @@
 import { Box } from '@mui/material';
 import { BottomMenuProps } from './index.types';
 import { useAppTranslation } from '@hooks/index';
+import useBottomMenu from './useBottomMenu';
+
+const GLOW_BOTTOM_SPACE =
+  'calc(var(--message-glow-small-offset-y) + var(--message-glow-small-blur))';
 
 const BottomMenu = (props: BottomMenuProps) => {
   const { t } = useAppTranslation();
+
+  const { menuRef } = useBottomMenu();
+
   return (
     <>
       <Box
@@ -12,7 +19,7 @@ const BottomMenu = (props: BottomMenuProps) => {
           bottom: 0,
           left: 0,
           right: 0,
-          height: '120px',
+          height: 'calc(120px + env(safe-area-inset-bottom, 0px))',
           background:
             'linear-gradient(180deg, rgba(var(--accent-100-base), 0) 0%, rgba(var(--accent-100-base), 0.85) 100%)',
           zIndex: (theme) => theme.zIndex.drawer,
@@ -21,6 +28,7 @@ const BottomMenu = (props: BottomMenuProps) => {
       />
       <Box
         component={'nav'}
+        ref={menuRef}
         aria-label={t('tr_bottomActionsMenu')}
         sx={{
           position: 'fixed',
@@ -28,13 +36,13 @@ const BottomMenu = (props: BottomMenuProps) => {
           border: '1px solid var(--accent-200)',
           borderRadius: 'var(--radius-xl)',
           overflow: 'hidden',
-          bottom: '16px',
+          bottom: `calc(${GLOW_BOTTOM_SPACE} + env(safe-area-inset-bottom, 0px))`,
           width: 'fit-content',
           maxWidth: 'calc(100% - 32px)',
           left: '50%',
           transform: 'translate(-50%)',
           zIndex: (theme) => theme.zIndex.drawer + 1,
-          boxShadow: 'var(--message-glow)',
+          boxShadow: 'var(--message-glow-small)',
           padding: '6px',
           display: 'flex',
           flexDirection: 'row',

--- a/src/layouts/bottom_menu/useBottomMenu.tsx
+++ b/src/layouts/bottom_menu/useBottomMenu.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react';
+
+const RESIZE_DURATION = 240;
+const GROW_EASING = 'cubic-bezier(0.2, 1.25, 0.35, 1)';
+// no undershoot: the menu is only as wide as its buttons, a dip cuts a label
+const SHRINK_EASING = 'cubic-bezier(0.2, 0.9, 0.3, 1)';
+
+// Animates the menu between the widths its changing sets of buttons ask for.
+const useBottomMenu = () => {
+  const menuRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const menu = menuRef.current;
+
+    if (!menu || typeof menu.animate !== 'function') return;
+
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    let previousWidth = menu.getBoundingClientRect().width;
+    let animation: Animation | null = null;
+
+    const observer = new ResizeObserver(() => {
+      // ignore the sizes the running animation reports
+      if (animation) return;
+
+      const width = menu.getBoundingClientRect().width;
+      const from = previousWidth;
+
+      previousWidth = width;
+
+      if (reduceMotion.matches || from === 0 || width === 0 || from === width) {
+        return;
+      }
+
+      animation = menu.animate(
+        [{ width: `${from}px` }, { width: `${width}px` }],
+        {
+          duration: RESIZE_DURATION,
+          easing: width > from ? GROW_EASING : SHRINK_EASING,
+        }
+      );
+
+      animation.finished
+        .then(() => {
+          previousWidth = menu.getBoundingClientRect().width;
+        })
+        .catch(() => null)
+        .finally(() => {
+          animation = null;
+        });
+    });
+
+    observer.observe(menu);
+
+    return () => {
+      animation?.cancel();
+      observer.disconnect();
+    };
+  }, []);
+
+  return { menuRef };
+};
+
+export default useBottomMenu;


### PR DESCRIPTION
# Description

The floating bottom menu keeps a 16px gap from the bottom of the screen, but its glow (`--message-glow`, `0px 8px 24px`) reaches 32px below the island, so the effect was cropped by the edge of the viewport. The menu now uses a softer glow whose offset and blur together fit inside that gap, and the gap itself is derived from those two variables so the position and the effect cannot drift apart.

Two related fixes to the same component:

- The menu is lifted by `env(safe-area-inset-bottom)`, so it stays clear of the Android system gesture bar when the installed PWA runs edge-to-edge, and the gradient behind it grows by the same inset. The value resolves to `0` where there is no inset, so nothing changes in the browser.
- The width of the menu is animated whenever its set of buttons changes, so moving between pages — or switching to a language with longer labels — no longer snaps it to a new size. The menu keeps its intrinsic `fit-content` width: a `ResizeObserver` picks up the new width and animates from the previous one, so nothing is measured on render. Growing settles with a small overshoot; shrinking is not allowed to undershoot, because the menu is only ever as wide as its buttons need and any dip below the target width cuts a label off.

Mobile only — the menu is rendered below the `tablet688` breakpoint.

Notes for review:

- `--message-glow-small` is defined in `src/global/index.css` rather than `global.css`, because the latter is generated from the Figma tokens by `npm run generate:css`.
- `viewport-fit=cover` was deliberately left out of the viewport meta. It would guarantee the safe area insets are populated on every platform, but it also pushes content under the status bar and notch, which needs a separate pass over the top navigation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
