### PR TITLE
fix(ui): replace date picker clear action with close

### DIFF
--- a/src/components/date_picker/index.tsx
+++ b/src/components/date_picker/index.tsx
@@ -117,16 +117,7 @@ const DatePicker = ({
           slots={{
             ...slotFieldProps,
             toolbar: () => <Toolbar selected={valueTmp} />,
-            actionBar: () => (
-              <ActionBar
-                onClose={() => setOpen(false)}
-                onClear={() => {
-                  setOpen(false);
-                  setValueTmp(null);
-                  onChange?.(null);
-                }}
-              />
-            ),
+            actionBar: () => <ActionBar onClose={() => setOpen(false)} />,
             openPickerIcon: IconDate,
             leftArrowIcon: hideNav ? () => <></> : ArrowLeft,
             rightArrowIcon: hideNav ? () => <></> : ArrowRight,

--- a/src/components/date_picker/slots/actionBar.tsx
+++ b/src/components/date_picker/slots/actionBar.tsx
@@ -4,10 +4,9 @@ import Button from '@components/button';
 
 type ActionBarProps = {
   onClose: VoidFunction;
-  onClear: VoidFunction;
 };
 
-const ActionBar = ({ onClose, onClear }: ActionBarProps) => {
+const ActionBar = ({ onClose }: ActionBarProps) => {
   const { t } = useAppTranslation();
 
   return (
@@ -17,8 +16,8 @@ const ActionBar = ({ onClose, onClear }: ActionBarProps) => {
       p={'12px'}
       gap={'12px'}
     >
-      <Button variant="secondary" onClick={onClear}>
-        {t('tr_clear')}
+      <Button variant="secondary" onClick={onClose}>
+        {t('tr_close')}
       </Button>
       <Button variant="main" onClick={onClose}>
         OK


### PR DESCRIPTION
# Description

The date picker action bar had a **Clear** button that set the value to `null`. Call sites do not treat the date as optional, so a cleared value was converted straight into a date — for example `new Date(date)` in the ministry report dialog — and the field rendered as `01/01/1970`.

No call site of `@components/date_picker` passed or relied on a clear handler, so the action is removed globally rather than disabled per usage. The left action is now **Close**: it dismisses the popup and leaves the selected date untouched.

Reproduced on Ministry → Report → Add record → date field → Clear.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
