### PR TITLE
tweak(ui): use accent color for midweek attendance date text

### DIFF
--- a/src/features/reports/meeting_attendance/monthly_record/week_box/index.tsx
+++ b/src/features/reports/meeting_attendance/monthly_record/week_box/index.tsx
@@ -41,7 +41,11 @@ const WeekBox = (props: WeekBoxProps) => {
           >
             <Typography
               className="body-small-semibold"
-              color={`var(--${props.type}-meeting)`}
+              color={
+                props.type === 'midweek'
+                  ? 'var(--accent-dark)'
+                  : 'var(--weekend-meeting)'
+              }
             >
               {box_label}
             </Typography>

--- a/src/features/reports/meeting_attendance/monthly_record/week_box/now_indicator/index.tsx
+++ b/src/features/reports/meeting_attendance/monthly_record/week_box/now_indicator/index.tsx
@@ -9,7 +9,9 @@ const NowIndicator = ({ type }: NowIndicatorProps) => {
     <Typography
       className="label-small-medium"
       textAlign="center"
-      color={`var(--${type}-meeting)`}
+      color={
+        type === 'midweek' ? 'var(--accent-dark)' : 'var(--weekend-meeting)'
+      }
     >
       • {t('tr_today')}
     </Typography>


### PR DESCRIPTION
# Description

On the Attendance page, the midweek meeting date label (and the "• Today" indicator below it) were colored with `--midweek-meeting` (blue). Those texts sit on the accent-tinted container background, so on the green theme — and other non-blue themes — the blue text clashed with its background.

This switches the midweek branch of both texts to `--accent-dark`, which is already the pattern used by the attendance summary tiles (`attendance_summary/index.tsx`) and the weekly total box in the same `week_box` component. The weekend branch is unchanged and keeps `--weekend-meeting`.

Files touched:

- `src/features/reports/meeting_attendance/monthly_record/week_box/index.tsx`
- `src/features/reports/meeting_attendance/monthly_record/week_box/now_indicator/index.tsx`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
