### PR TITLE
feat(ui): animate the date switch in the meeting week navigator

### DIFF
--- a/src/components/date_navigator/index.tsx
+++ b/src/components/date_navigator/index.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useRef, useState } from 'react';
+import { Box, useTheme } from '@mui/material';
+import { IconNavigateLeft, IconNavigateRight } from '@components/icons';
+import { DateNavigatorDirection, DateNavigatorType } from './index.types';
+import { useAppTranslation } from '@hooks/index';
+import ButtonIcon from '@components/icon_button';
+import Typography from '@components/typography';
+
+const DURATION = 320;
+const DISTANCE = 40;
+const EASING = 'cubic-bezier(0.22, 1, 0.36, 1)';
+const BLEED = 48;
+const FADE = 32;
+
+const EDGE_FADE = [
+  'linear-gradient(to right',
+  'transparent 0',
+  `transparent ${BLEED - FADE}px`,
+  `#000 ${BLEED}px`,
+  `#000 calc(100% - ${BLEED}px)`,
+  `transparent calc(100% - ${BLEED - FADE}px)`,
+  'transparent 100%)',
+].join(', ');
+
+const keyframes = {
+  '@keyframes date-navigator-enter-left': {
+    from: { opacity: 0, transform: `translateX(-${DISTANCE}px)` },
+    to: { opacity: 1, transform: 'translateX(0)' },
+  },
+  '@keyframes date-navigator-enter-right': {
+    from: { opacity: 0, transform: `translateX(${DISTANCE}px)` },
+    to: { opacity: 1, transform: 'translateX(0)' },
+  },
+  '@keyframes date-navigator-exit-left': {
+    from: { opacity: 1, transform: 'translateX(0)' },
+    to: { opacity: 0, transform: `translateX(-${DISTANCE}px)` },
+  },
+  '@keyframes date-navigator-exit-right': {
+    from: { opacity: 1, transform: 'translateX(0)' },
+    to: { opacity: 0, transform: `translateX(${DISTANCE}px)` },
+  },
+};
+
+type Model = {
+  value: string;
+  seq: number;
+  direction: DateNavigatorDirection;
+  exiting: {
+    seq: number;
+    value: string;
+    direction: DateNavigatorDirection;
+  } | null;
+};
+
+const DateNavigator = ({
+  value,
+  onBack,
+  onNext,
+  disableBack,
+  disableNext,
+  labelClassName = 'h2',
+  labelMinWidth,
+  sx,
+}: DateNavigatorType) => {
+  const { t } = useAppTranslation();
+
+  const theme = useTheme();
+
+  const isRtl = theme.direction === 'rtl';
+
+  const directionRef = useRef<DateNavigatorDirection>('next');
+
+  const [model, setModel] = useState<Model>({
+    value,
+    seq: 0,
+    direction: 'next',
+    exiting: null,
+  });
+
+  const backActive = !disableBack && !!onBack;
+  const nextActive = !disableNext && !!onNext;
+
+  if (model.value !== value) {
+    setModel((prev) => ({
+      value,
+      seq: prev.seq + 1,
+      direction: directionRef.current,
+      exiting: {
+        seq: prev.seq + 1,
+        value: prev.value,
+        direction: directionRef.current,
+      },
+    }));
+  }
+
+  useEffect(() => {
+    if (!model.exiting) return;
+
+    const exitingSeq = model.exiting.seq;
+
+    const id = setTimeout(() => {
+      setModel((prev) =>
+        prev.exiting?.seq === exitingSeq ? { ...prev, exiting: null } : prev
+      );
+    }, DURATION);
+
+    return () => clearTimeout(id);
+  }, [model.exiting]);
+
+  const swapping = model.exiting !== null;
+
+  const enterSide = (direction: DateNavigatorDirection) => {
+    const side = direction === 'next' ? 'right' : 'left';
+
+    if (!isRtl) return side;
+
+    return side === 'right' ? 'left' : 'right';
+  };
+
+  const exitSide = (direction: DateNavigatorDirection) =>
+    enterSide(direction) === 'right' ? 'left' : 'right';
+
+  const handleBack = () => {
+    directionRef.current = 'back';
+    onBack?.();
+  };
+
+  const handleNext = () => {
+    directionRef.current = 'next';
+    onNext?.();
+  };
+
+  const arrowStyles = {
+    padding: '8px',
+    position: 'relative',
+    zIndex: 1,
+    transition: `transform ${DURATION}ms ${EASING}`,
+    '&:active': { transform: 'scale(0.88)' },
+    '@media (prefers-reduced-motion: reduce)': {
+      transition: 'none',
+      '&:active': { transform: 'none' },
+    },
+  };
+
+  const labelStyles = {
+    textAlign: 'center',
+    whiteSpace: 'nowrap',
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: '8px',
+        ...keyframes,
+        ...sx,
+      }}
+    >
+      <ButtonIcon
+        disableHover
+        disabled={!backActive}
+        aria-label={t('tr_back')}
+        onClick={handleBack}
+        sx={arrowStyles}
+      >
+        <IconNavigateLeft
+          color={backActive ? 'var(--black)' : 'var(--grey-300)'}
+        />
+      </ButtonIcon>
+
+      <Box
+        sx={{
+          position: 'relative',
+          flexGrow: 1,
+          display: 'flex',
+          justifyContent: 'center',
+          minWidth: labelMinWidth,
+          paddingInline: `${BLEED}px`,
+          marginInline: `-${BLEED}px`,
+          pointerEvents: 'none',
+          maskImage: swapping ? EDGE_FADE : 'none',
+          WebkitMaskImage: swapping ? EDGE_FADE : 'none',
+        }}
+      >
+        <Typography
+          key={`in-${model.seq}`}
+          className={labelClassName}
+          sx={{
+            ...labelStyles,
+            animation:
+              model.seq > 0
+                ? `date-navigator-enter-${enterSide(model.direction)} ${DURATION}ms ${EASING}`
+                : 'none',
+            '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+          }}
+        >
+          {model.value}
+        </Typography>
+
+        {model.exiting && (
+          <Box
+            aria-hidden
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              justifyContent: 'center',
+              pointerEvents: 'none',
+            }}
+          >
+            <Typography
+              key={`out-${model.exiting.seq}`}
+              className={labelClassName}
+              sx={{
+                ...labelStyles,
+                animation: `date-navigator-exit-${exitSide(model.exiting.direction)} ${DURATION}ms ${EASING} forwards`,
+                '@media (prefers-reduced-motion: reduce)': {
+                  animation: 'none',
+                  opacity: 0,
+                },
+              }}
+            >
+              {model.exiting.value}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+
+      <ButtonIcon
+        disableHover
+        disabled={!nextActive}
+        aria-label={t('tr_next')}
+        onClick={handleNext}
+        sx={arrowStyles}
+      >
+        <IconNavigateRight
+          color={nextActive ? 'var(--black)' : 'var(--grey-300)'}
+        />
+      </ButtonIcon>
+    </Box>
+  );
+};
+
+export default DateNavigator;

--- a/src/components/date_navigator/index.types.ts
+++ b/src/components/date_navigator/index.types.ts
@@ -1,0 +1,15 @@
+import { SxProps, Theme } from '@mui/material';
+import { CustomClassName } from '@definition/app';
+
+export type DateNavigatorDirection = 'back' | 'next';
+
+export type DateNavigatorType = {
+  value: string;
+  onBack?: VoidFunction;
+  onNext?: VoidFunction;
+  disableBack?: boolean;
+  disableNext?: boolean;
+  labelClassName?: CustomClassName;
+  labelMinWidth?: string | number;
+  sx?: SxProps<Theme>;
+};

--- a/src/features/meetings/midweek_editor/index.styles.tsx
+++ b/src/features/meetings/midweek_editor/index.styles.tsx
@@ -12,8 +12,3 @@ export const PersonDoubleContainer = styled(Box)({
   flexDirection: 'column',
   gap: '16px',
 }) as unknown as typeof Box;
-
-export const StyledNavigationArrowButton = styled(Box)({
-  display: 'flex',
-  alignItems: 'center',
-}) as unknown as typeof Box;

--- a/src/features/meetings/midweek_editor/index.tsx
+++ b/src/features/meetings/midweek_editor/index.tsx
@@ -4,8 +4,6 @@ import {
   IconLivingPart,
   IconLock,
   IconMinistryPart,
-  IconNavigateLeft,
-  IconNavigateRight,
   IconTreasuresPart,
 } from '@components/icons';
 import {
@@ -27,7 +25,6 @@ import {
 import {
   ClassAssignmentContainer,
   PersonDoubleContainer,
-  StyledNavigationArrowButton,
 } from './index.styles';
 import { useAppTranslation, useBreakpoints } from '@hooks/index';
 import { setIsImportJWOrg } from '@services/states/sources';
@@ -39,6 +36,7 @@ import BrotherAssignment from './brother_assignment';
 import Button from '@components/button';
 import ButtonGroup from '@components/button_group';
 import COTalk from './co_talk';
+import DateNavigator from '@components/date_navigator';
 import Divider from '@components/divider';
 import EventEditor from '../event_editor';
 import LivingContainer from './living_container';
@@ -125,45 +123,18 @@ const MidweekEditor = () => {
             gap: '16px',
           }}
         >
-          <Box
+          <DateNavigator
+            value={weekDateLocale}
+            onBack={handleChangeWeekBack}
+            onNext={handleChangeWeekNext}
+            disableBack={!showWeekArrows.back}
+            disableNext={!showWeekArrows.next}
+            labelMinWidth={tablet500Down ? undefined : '140px'}
             sx={{
-              display: 'flex',
-              flexDirection: 'row',
-              gap: '16px',
-              justifyContent: tablet500Down && 'space-between',
+              width: tablet500Down ? '100%' : 'auto',
+              alignSelf: 'flex-start',
             }}
-          >
-            <StyledNavigationArrowButton
-              onClick={showWeekArrows.back ? handleChangeWeekBack : undefined}
-              sx={{
-                cursor: showWeekArrows.back && 'pointer',
-              }}
-            >
-              <IconNavigateLeft
-                color={showWeekArrows.back ? 'var(--black)' : 'var(--grey-300)'}
-              />
-            </StyledNavigationArrowButton>
-
-            <Typography
-              className="h2"
-              sx={{
-                minWidth: !tablet500Down && '140px',
-                textAlign: 'center',
-              }}
-            >
-              {weekDateLocale}
-            </Typography>
-            <StyledNavigationArrowButton
-              onClick={showWeekArrows.next ? handleChangeWeekNext : undefined}
-              sx={{
-                cursor: showWeekArrows.next && 'pointer',
-              }}
-            >
-              <IconNavigateRight
-                color={showWeekArrows.next ? 'var(--black)' : 'var(--grey-300)'}
-              />
-            </StyledNavigationArrowButton>
-          </Box>
+          />
 
           <DoubleFieldContainer
             sx={{ flexDirection: laptopUp ? 'row' : 'column' }}


### PR DESCRIPTION
# Description

The `< week >` switcher above the midweek meeting editor replaced its label instantly, so nothing told you which way the schedule had moved.

This extracts that switcher into a shared `DateNavigator` component in `@components/`, and gives the label a directional swap: clicking next pushes the current week out to the left while the new one arrives from the right, and back reverses it. It is the same directional swap the clicker mode uses when switching between the online and present counts, so the two read as one motion language.

Details:

- **Global component**, ready for any other date, week or month switcher — it was the only arrow switcher in the app, but no longer has to be.
- **320ms travel** on a soft ease-out (`cubic-bezier(0.22, 1, 0.36, 1)`), with the direction mirrored in RTL layouts.
- **Gradient mask only while the swap is running.** The mask is fully opaque across the middle band and ramps down only over the arrow zone, so the label at rest is never dimmed and the travelling one dissolves instead of hitting a hard clip edge.
- **Accessibility:** the arrows are now `ButtonIcon`s — focusable, keyboard-operable, with translated `aria-label`s and a visible focus ring. The outgoing label is `aria-hidden`. `prefers-reduced-motion` disables the animation entirely.
- **Multi-language:** the label is `white-space: nowrap` and centred, and a long locale simply fades toward the arrows instead of wrapping mid-flight.

No new dependencies, no schema changes, no new translation keys — the arrow labels reuse the existing `tr_back` and `tr_next`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
