### PR TITLE
fix(meetings): allow assignment for Living as Christians video discussion

### DIFF
--- a/src/features/meetings/midweek_editor/brother_assignment/useBrotherAssignment.tsx
+++ b/src/features/meetings/midweek_editor/brother_assignment/useBrotherAssignment.tsx
@@ -101,8 +101,17 @@ const useBrotherAssignment = ({
 
       const lcSrc = lcSrcOverride?.length > 0 ? lcSrcOverride : lcSrcDefault;
 
+      const lcDescOverride = lcPart.desc.override.find(
+        (record) => record.type === dataView
+      )?.value;
+
+      const lcDescDefault = lcPart.desc.default[lang];
+
+      const lcDesc =
+        lcDescOverride?.length > 0 ? lcDescOverride : lcDescDefault;
+
       if (lcSrc?.length > 0) {
-        return !sourcesCheckLCAssignments(lcSrc, sourceLocale);
+        return !sourcesCheckLCAssignments(lcSrc, lcDesc, sourceLocale);
       }
     }
 
@@ -112,8 +121,11 @@ const useBrotherAssignment = ({
       const lcSrc =
         lcPart.title.find((record) => record.type === dataView)?.value || '';
 
+      const lcDesc =
+        lcPart.desc.find((record) => record.type === dataView)?.value || '';
+
       if (lcSrc.length > 0) {
-        return !sourcesCheckLCAssignments(lcSrc, sourceLocale);
+        return !sourcesCheckLCAssignments(lcSrc, lcDesc, sourceLocale);
       }
     }
   }, [type, source, dataView, lang, sourceLocale]);

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -300,6 +300,15 @@ const useMonthlyView = () => {
 
         const lcSrc = lcSrcOverride?.length > 0 ? lcSrcOverride : lcSrcDefault;
 
+        const lcDescOverride = lcSrcPart.desc.override.find(
+          (record) => record.type === dataView
+        )?.value;
+
+        const lcDescDefault = lcSrcPart.desc.default[lang];
+
+        const lcDesc =
+          lcDescOverride?.length > 0 ? lcDescOverride : lcDescDefault;
+
         if (setterIndex + 1 === 1 || setterIndex + 1 === 2) {
           changeValueInArrayState(
             isOverwriteLCPartsSetters[setterIndex],
@@ -309,7 +318,7 @@ const useMonthlyView = () => {
         }
 
         if (lcSrc?.length > 0) {
-          const noAssign = sourcesCheckLCAssignments(lcSrc, lang);
+          const noAssign = sourcesCheckLCAssignments(lcSrc, lcDesc, lang);
           changeValueInArrayState(setter, index, noAssign);
         }
       });
@@ -319,8 +328,13 @@ const useMonthlyView = () => {
           (record) => record.type === dataView
         )?.value || '';
 
+      const lc3Desc =
+        source.midweek_meeting.lc_part3.desc.find(
+          (record) => record.type === dataView
+        )?.value || '';
+
       if (lc3Src.length > 0) {
-        const noAssign = sourcesCheckLCAssignments(lc3Src, lang);
+        const noAssign = sourcesCheckLCAssignments(lc3Src, lc3Desc, lang);
         changeValueInArrayState(setLcNoAssignParts3, index, noAssign);
       }
     });

--- a/src/locales/de-DE/forms-templates.json
+++ b/src/locales/de-DE/forms-templates.json
@@ -54,6 +54,7 @@
   "tr_initialCallVariations": "0",
   "tr_returnVisitVariations": "0",
   "tr_lcNoAssignedVariations": "Ergebnisse unserer organisierten Tätigkeit|Aktueller Lagebericht der Leitenden Körperschaft",
+  "tr_lcNoAssignedContentVariations": "Zeige das VIDEO",
   "tr_cbsLffWithPointsVariations": "lff Lektion {{ lesson }} Punkte {{ points }}|lff Lektion {{ lesson }} Punkt {{ points }}",
   "tr_cbsLffSectionOnlyVariations": "lff Abschnitt",
   "tr_lcSourceElderVariations": "Aktuelles",

--- a/src/locales/en/forms-templates.json
+++ b/src/locales/en/forms-templates.json
@@ -54,6 +54,7 @@
   "tr_initialCallVariations": "0",
   "tr_returnVisitVariations": "0",
   "tr_lcNoAssignedVariations": "Organizational Accomplishments|Governing Body Update",
+  "tr_lcNoAssignedContentVariations": "Play the VIDEO",
   "tr_cbsLffWithPointsVariations": "lff lesson {{ lesson }} points {{ points }}|lff lesson {{ lesson }} point {{ points }}",
   "tr_cbsLffSectionOnlyVariations": "lff section",
   "tr_lcSourceElderVariations": "Local Needs",

--- a/src/locales/he-IL/forms-templates.json
+++ b/src/locales/he-IL/forms-templates.json
@@ -54,6 +54,7 @@
   "tr_initialCallVariations": "0",
   "tr_returnVisitVariations": "0",
   "tr_lcNoAssignedVariations": "הישגים ארגוניים|עדכון מטעם הגוף המנהל",
+  "tr_lcNoAssignedContentVariations": "הסרטון",
   "tr_cbsLffWithPointsVariations": "שיעור lff {{ lesson }} נקודות {{ points }}|שיעור lff {{ lesson }} נקודה {{ points }}",
   "tr_cbsLffSectionOnlyVariations": "חלק lff",
   "tr_lcSourceElderVariations": "צרכים מקומיים",

--- a/src/services/app/autofill.ts
+++ b/src/services/app/autofill.ts
@@ -293,7 +293,7 @@ const handleMMAssignLCStandard = (
   let isElderPart = false;
 
   if (title.length > 0) {
-    noAssignLC = sourcesCheckLCAssignments(title, sourceLocale);
+    noAssignLC = sourcesCheckLCAssignments(title, desc, sourceLocale);
 
     if (!noAssignLC) {
       const lcAssign = schedule.midweek_meeting[
@@ -346,7 +346,7 @@ const handleMMAssignLCCustom = (
     lcPart3.desc.find((record) => record.type === dataView)?.value ?? '';
 
   if (title.length > 0) {
-    const noAssignLC = sourcesCheckLCAssignments(title, sourceLocale);
+    const noAssignLC = sourcesCheckLCAssignments(title, desc, sourceLocale);
 
     if (!noAssignLC) {
       main =

--- a/src/services/app/schedules.ts
+++ b/src/services/app/schedules.ts
@@ -431,8 +431,14 @@ export const schedulesMidweekInfo = (week: string) => {
       const titleDefault = lcPart.title.default[lang];
       const title = titleOverride?.length > 0 ? titleOverride : titleDefault;
 
+      const descOverride = lcPart.desc.override.find(
+        (record) => record.type === dataView
+      )?.value;
+      const descDefault = lcPart.desc.default[lang];
+      const desc = descOverride?.length > 0 ? descOverride : descDefault;
+
       if (title?.length > 0) {
-        const noAssign = sourcesCheckLCAssignments(title, sourceLocale);
+        const noAssign = sourcesCheckLCAssignments(title, desc, sourceLocale);
 
         if (!noAssign) {
           total = total + 1;
@@ -465,8 +471,11 @@ export const schedulesMidweekInfo = (week: string) => {
     const title =
       lcPart.title.find((record) => record.type === dataView)?.value || '';
 
+    const desc =
+      lcPart.desc.find((record) => record.type === dataView)?.value || '';
+
     if (title?.length > 0) {
-      const noAssign = sourcesCheckLCAssignments(title, sourceLocale);
+      const noAssign = sourcesCheckLCAssignments(title, desc, sourceLocale);
 
       if (!noAssign) {
         total = total + 1;

--- a/src/services/app/sources.ts
+++ b/src/services/app/sources.ts
@@ -316,7 +316,11 @@ export const sourcesCheckLCElderAssignment = (
   return false;
 };
 
-export const sourcesCheckLCAssignments = (source: string, language: string) => {
+export const sourcesCheckLCAssignments = (
+  source: string,
+  desc: string | undefined,
+  language: string
+) => {
   if (source) {
     const noAssigned = getTranslation({
       key: 'tr_lcNoAssignedVariations',
@@ -327,7 +331,19 @@ export const sourcesCheckLCAssignments = (source: string, language: string) => {
     const regex = new RegExp(search.toLowerCase());
     const array = regex.exec(source.toLowerCase());
 
-    return Array.isArray(array);
+    if (!Array.isArray(array)) return false;
+
+    if (!desc) return true;
+
+    const videoContent = getTranslation({
+      key: 'tr_lcNoAssignedContentVariations',
+      language,
+    });
+
+    const videoSearch = `(${videoContent})`;
+    const videoRegex = new RegExp(videoSearch.toLowerCase());
+
+    return Array.isArray(videoRegex.exec(desc.toLowerCase()));
   }
 
   return false;


### PR DESCRIPTION
# Description

Living as Christians parts titled "Organizational Accomplishments" or "Governing Body Update" are matched against `tr_lcNoAssignedVariations` and treated as parts that never get an assignee. That was correct while these parts were video only (`Play the VIDEO.`). Since the 2026 workbook the same parts are handled as a discussion (`Discussion.`) and need a brother assigned, but the assignment field stays hidden, so the part cannot be scheduled, is skipped by autofill, and prints on the S-140 with an empty person column.

Reported for the week of September 14, 2026 (part 9), the same happens for March 2, 2026 and August 3, 2026. Source materials are correct in every language checked (English, German, Hebrew) — the part is present with `lc_count = 2` — so this is purely the client-side check.

`sourcesCheckLCAssignments` now takes the part content in addition to the title and only skips the assignment when the content is a video, using a new `tr_lcNoAssignedContentVariations` key. Callers in the midweek editor, monthly view, schedule progress counter and autofill pass the content along. Locales without the new key fall back to showing the assignment field rather than hiding it.

Verified against the full source materials feed (113 weeks x English, German, Hebrew): only the 2026 discussion weeks become assignable, every earlier video week keeps its current behaviour.

Fixes #5334

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
