### PR TITLE
feat(github): ask for app and source materials languages in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -71,6 +71,24 @@ body:
         For example: v.3.0.0
     validations:
       required: true
+  - type: input
+    attributes:
+      label: 'App UI language:'
+      description: |
+        The language the app interface is displayed in.
+      placeholder: |
+        For example: English, Malagasy, Spanish, etc
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: 'Meeting source materials language:'
+      description: |
+        The language your meeting materials are imported in, set in your congregation settings. It may sometimes differ from the app UI language.
+      placeholder: |
+        For example: French, Ukrainian, Italian, etc
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: 'Additional information'


### PR DESCRIPTION
# Description

Bug reports are often language dependent, but the bug report form never asks which language the app is used in. Two different languages matter and they are usually not the same one:

- the app display language, which points at a translation or interface issue
- the meeting source materials language, which points at an issue with the imported program

Both had to be asked for in follow-up comments, which slows down triage. A recent example is #5334, where the reported part could not be assigned and the first question was whether the source materials language was involved.

Both fields are now required inputs in the bug report form, placed right after the app version. Free text was chosen over a dropdown because the app supports a large and growing list of languages.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
