### PR TITLE
tweak(ui): improve the action button color

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -34,7 +34,7 @@ const Button: FC<ButtonPropsType> = (props) => {
   const overlayBorderTop =
     'linear-gradient(180deg, rgba(255, 255, 255, 0.32) 0%, rgba(255, 255, 255, 0) 100%)';
   const overlayBorderBottom =
-    'linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.05) 100%)';
+    'linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.02) 100%)';
   const gradientBackground = `${topHighlight}, ${overlayBorderTop}, ${overlayBorderBottom}`;
 
   const darkenOverlay = 'inset 0 0 0 1000px var(--btn-hover-overlay)';
@@ -44,7 +44,10 @@ const Button: FC<ButtonPropsType> = (props) => {
   const springEasing = 'cubic-bezier(0.34, 1.56, 0.64, 1)';
 
   const hasPressScale =
-    isGradient || variant === 'secondary' || variant === 'tertiary';
+    isGradient ||
+    variant === 'secondary' ||
+    variant === 'tertiary' ||
+    variant === 'semi-white';
 
   const getBorder = (isDisabled = false) => {
     if (isGradient) {

--- a/src/features/reminders/index.tsx
+++ b/src/features/reminders/index.tsx
@@ -69,7 +69,7 @@ const AppReminders = () => {
         </Stack>
 
         <StyledRemindersFooter>
-          <Button variant="main" color="orange" onClick={reminderMeTomorrow}>
+          <Button variant="semi-white" onClick={reminderMeTomorrow}>
             {t('tr_remindMeTomorrow')}
           </Button>
         </StyledRemindersFooter>


### PR DESCRIPTION
# Description

- Soften the bottom darkening overlay of the action button gradient from `0.05` to `0.02` opacity to eliminate the harsh dark band on light theme while maintaining subtle depth.
- Add `variant === 'semi-white'` to `hasPressScale` for consistent spring micro-interaction on click.
- Update the reminders notification button from `variant="main"` with `color="orange"` to `variant="semi-white"` for clean contrast against the orange card background.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
