### PR TITLE
fix(weekly): display opening and concluding comments in midweek schedule

### DIFF
--- a/src/features/meetings/weekly_schedules/midweek_meeting/index.tsx
+++ b/src/features/meetings/weekly_schedules/midweek_meeting/index.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { IconWavingHand } from '@components/icons';
 import { Week } from '@definition/week_type';
 import {
@@ -188,6 +188,32 @@ const MidweekMeeting = (props: MidweekMeetingProps) => {
                   }
                 />
               </SecondaryFieldContainer>
+            </DoubleFieldContainer>
+          )}
+
+          {MIDWEEK_FULL.includes(weekType) && (
+            <DoubleFieldContainer
+              sx={{ flexDirection: laptopUp ? 'row' : 'column' }}
+            >
+              <PrimaryFieldContainer>
+                {partTimings?.opening_comments && (
+                  <PartTiming time={partTimings.opening_comments} />
+                )}
+
+                <Box
+                  sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}
+                >
+                  <Typography
+                    className="h4"
+                    color="var(--treasures-from-gods-word)"
+                  >
+                    {`${t('tr_openingComments')} ${t('tr_partDuration', { time: 1 })}`}
+                  </Typography>
+                </Box>
+              </PrimaryFieldContainer>
+              <SecondaryFieldContainer
+                sx={{ maxWidth: laptopUp ? '360px' : '100%' }}
+              />
             </DoubleFieldContainer>
           )}
 

--- a/src/features/meetings/weekly_schedules/midweek_meeting/living_part/index.tsx
+++ b/src/features/meetings/weekly_schedules/midweek_meeting/living_part/index.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { IconLivingPart } from '@components/icons';
 import { Week } from '@definition/week_type';
 import {
@@ -18,6 +18,7 @@ import PartRow from './part_row';
 import PartTiming from '../../part_timing';
 import PersonComponent from '../../person_component';
 import SongSource from '@features/meetings/song_source';
+import Typography from '@components/typography';
 
 const LivingPart = (props: LivingPartProps) => {
   const { t } = useAppTranslation();
@@ -96,6 +97,39 @@ const LivingPart = (props: LivingPartProps) => {
                   dataView={props.dataView}
                 />
               </Stack>
+            </SecondaryFieldContainer>
+          </DoubleFieldContainer>
+        )}
+
+        {MIDWEEK_FULL.includes(weekType) && (
+          <DoubleFieldContainer
+            sx={{ flexDirection: laptopUp ? 'row' : 'column' }}
+          >
+            <PrimaryFieldContainer>
+              {props.timings?.concluding_comments && (
+                <PartTiming time={props.timings.concluding_comments} />
+              )}
+
+              <Box
+                sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}
+              >
+                <Typography
+                  className="h4"
+                  color="var(--living-as-christians)"
+                >
+                  {`${t('tr_concludingComments')} ${t('tr_partDuration', { time: 3 })}`}
+                </Typography>
+              </Box>
+            </PrimaryFieldContainer>
+            <SecondaryFieldContainer
+              sx={{ maxWidth: laptopUp ? '360px' : '100%' }}
+            >
+              <PersonComponent
+                label={`${t('tr_chairman')}:`}
+                week={props.week}
+                assignment="MM_Chairman_A"
+                dataView={props.dataView}
+              />
             </SecondaryFieldContainer>
           </DoubleFieldContainer>
         )}


### PR DESCRIPTION
Closes #4344

### What this fixes

Weekly Schedules for the midweek meeting omitted Opening Comments (1 min) and Concluding Comments (3 min). Chairman had to switch to the workbook to manage full timing. The screenshot workflow was missing 4 minutes per week.

### The change

- Add Opening Comments row after opening song and prayer, before Treasures, using `partTimings.opening_comments` from `schedulesMidweekGetTiming`
- Add Concluding Comments row before closing song and prayer, after CBS, using `partTimings.concluding_comments`, assigned to chairman
- Show only when `MIDWEEK_FULL` (Normal, CO visit), hide on assembly, memorial and no meeting weeks
- For CO visit, order is concluding then co talk 30 min then closing, matching S-140 and `schedulesMidweekGetTiming`
- Uses existing timing so no schema change, follows S-140 pattern `S140/default/index.tsx:104` and `:317`

### Testing

- Before: weekly schedule shows pgm_start then tgw_talk, and cbs then pgm_end
- After: shows pgm_start, opening comments 1 min, then treasures, and cbs, concluding 3 min with chairman, then pgm_end
- Verified `npm run build` passes for weekly files, `MIDWEEK_FULL` guard prevents regression on special weeks
- Chairman mode future change can adjust this later

### Screenshots

- To be added after Vercel preview
