### PR TITLE
fix(sync): restore congregation field service reports for elders and overseers

### DIFF
--- a/src/indexedDb/appDb.ts
+++ b/src/indexedDb/appDb.ts
@@ -182,6 +182,30 @@ appDb.version(12).stores({
   ...upcomingEventsSchema,
 });
 
+appDb
+  .version(13)
+  .stores({
+    ...schema,
+    ...metadataSchema,
+    ...delegatedFieldServiceReportsSchema,
+    ...weekTypeSchema,
+    ...publicTalkSchema,
+    ...songSchema,
+    ...upcomingEventsSchema,
+  })
+  .upgrade(async (tx) => {
+    // congregation reports were dropped on restore for elders and group
+    // overseers while their version kept advancing: clear it once so the
+    // next sync pulls the reports they never received
+    const record = await tx.table('metadata').get(1);
+
+    if (!record?.metadata?.cong_field_service_reports) return;
+
+    record.metadata.cong_field_service_reports.version = '';
+
+    await tx.table('metadata').put(record);
+  });
+
 appDb.on('populate', function () {
   appDb.app_settings.add(settingSchema);
 });

--- a/src/services/worker/backupUtils.ts
+++ b/src/services/worker/backupUtils.ts
@@ -9,6 +9,7 @@ import {
   encryptObject,
   generateKey,
 } from '@services/encryption';
+import { AppRoleType } from '@definition/app';
 import { PersonType, PrivilegeType } from '@definition/person';
 import {
   OutgoingTalkExportScheduleType,
@@ -231,6 +232,22 @@ export const dbGetSettings = async () => {
   return settings;
 };
 
+// congregation reports are readable and writable by the same roles on the API,
+// so every gate in this file must resolve them the same way
+const isReportEditorRole = (userRole: AppRoleType[]) => {
+  const adminRole =
+    userRole.includes('admin') ||
+    userRole.includes('secretary') ||
+    userRole.includes('coordinator');
+
+  return (
+    adminRole ||
+    userRole.includes('elder') ||
+    userRole.includes('group_overseers') ||
+    userRole.includes('language_group_overseers')
+  );
+};
+
 export const isMondayDate = (date: string) => {
   const inputDate = new Date(date);
   const dayOfWeek = inputDate.getDay();
@@ -278,10 +295,15 @@ export const dbGetMetadata = async () => {
   const isAttendanceTracker =
     isAdmin || userRole.some((role) => role === 'attendance_tracking');
 
+  const isReportEditor = isReportEditorRole(userRole);
+
   if (!isPublisher) {
     delete result.user_bible_studies;
     delete result.user_field_service_reports;
     delete result.delegated_field_service_reports;
+  }
+
+  if (!isPublisher && !isReportEditor) {
     delete result.cong_field_service_reports;
   }
 
@@ -1049,13 +1071,9 @@ const dbRestoreCongReports = async (
 
     const userRole = settings.user_settings.cong_role;
 
-    const secretaryRole = userRole.includes('secretary');
-    const coordinatorRole = userRole.includes('coordinator');
-    const adminRole =
-      userRole.includes('admin') || secretaryRole || coordinatorRole;
     const publisherRole = userRole.includes('publisher');
 
-    const allowRestore = adminRole || publisherRole;
+    const allowRestore = isReportEditorRole(userRole) || publisherRole;
 
     if (allowRestore) {
       const remoteData = (
@@ -1640,8 +1658,6 @@ export const dbExportDataBackup = async (backupData: BackupDataType) => {
 
     const secretaryRole = userRole.includes('secretary');
     const coordinatorRole = userRole.includes('coordinator');
-    const elderRole = userRole.includes('elder');
-    const groupOverseerRole = userRole.includes('group_overseers');
     const languageGroupOverseerRole = userRole.includes(
       'language_group_overseers'
     );
@@ -1843,10 +1859,7 @@ export const dbExportDataBackup = async (backupData: BackupDataType) => {
 
         // include field service reports
         if (
-          (adminRole ||
-            elderRole ||
-            groupOverseerRole ||
-            languageGroupOverseerRole) &&
+          isReportEditorRole(userRole) &&
           metadata.metadata.cong_field_service_reports.send_local
         ) {
           const backupReports = cong_field_service_reports.map((report) => {


### PR DESCRIPTION
# Description

Elders, group overseers and language group overseers never receive congregation field service reports through sync, and can silently overwrite the reports of other users.

`dbExportDataBackup` lets those roles **upload** `cong_field_service_reports`, and the API sends the table to them (`reportEditorRole`). But `dbRestoreCongReports` gated the **restore** on `adminRole || publisherRole`, where `publisher` is a pocket-only role that VIP accounts usually do not carry. So those users:

- received the reports and dropped them without any error,
- still advanced the `cong_field_service_reports` metadata version, so the data was never requested again,
- pushed their own stale table back, and since the API replaces the stored file as a whole, reports another user had just synced were removed.

This is the mismatch behind #5055: the second user keeps syncing and never sees the reports.

The restore gate lost its group overseer branch in f200e6b05 when the dedicated `group_overseers` role was introduced, and was never given the new role.

What this changes:

- resolve the report editor roles in one helper and use it for the restore gate, the export gate and the metadata sent to the API, so the three can no longer drift apart
- send the `cong_field_service_reports` version for those roles again, which also re-arms the API check that rejects outdated backups
- clear that version once on database upgrade, so clients that dropped reports pull them on the next sync instead of trusting a version they never applied

Fixes #5055

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sws2apps/organized-app/pull/5382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->