### PR TITLE
fix(reports): let group overseers receive congregation field service reports

### DIFF
--- a/src/services/worker/backupUtils.ts
+++ b/src/services/worker/backupUtils.ts
@@ -31,6 +31,29 @@ import { DelegatedFieldServiceReportType } from '@definition/delegated_field_ser
 import { UpcomingEventType } from '@definition/upcoming_events';
 import { formatDate } from '@utils/date';
 import { APP_READ_ONLY_ROLES } from '@constants/index';
+import { AppRoleType } from '@definition/app';
+
+const isAdminRole = (userRole: AppRoleType[]) =>
+  userRole.includes('admin') ||
+  userRole.includes('secretary') ||
+  userRole.includes('coordinator');
+
+/**
+ * Roles with a UI for congregation-wide field service reports. Must stay in
+ * sync with the /reports/field-service route guard in App.tsx.
+ */
+const isCongReportsViewer = (userRole: AppRoleType[]) =>
+  isAdminRole(userRole) ||
+  userRole.includes('group_overseers') ||
+  userRole.includes('language_group_overseers');
+
+/** Senders also include elders. */
+const canSendCongReports = (userRole: AppRoleType[]) =>
+  isCongReportsViewer(userRole) || userRole.includes('elder');
+
+/** Receivers also include publishers. */
+const canReceiveCongReports = (userRole: AppRoleType[]) =>
+  isCongReportsViewer(userRole) || userRole.includes('publisher');
 
 const personIsElder = (person: PersonType) => {
   const hasActive = person?.person_data.privileges?.find(
@@ -254,9 +277,9 @@ export const dbGetMetadata = async () => {
   const userRole = settings.user_settings.cong_role;
 
   const isSecretary = userRole.includes('secretary');
-  const isCoordinator = userRole.includes('coordinator');
-  const isAdmin = userRole.includes('admin') || isSecretary || isCoordinator;
+  const isAdmin = isAdminRole(userRole);
   const isPublisher = isAdmin || userRole.includes('publisher');
+  const isCongReportsReceiver = canReceiveCongReports(userRole);
   const isGroupOverseer = isAdmin || userRole.includes('group_overseers');
   const isLanguageGroupOverseer =
     isAdmin || userRole.includes('language_group_overseers');
@@ -282,6 +305,9 @@ export const dbGetMetadata = async () => {
     delete result.user_bible_studies;
     delete result.user_field_service_reports;
     delete result.delegated_field_service_reports;
+  }
+
+  if (!isCongReportsReceiver) {
     delete result.cong_field_service_reports;
   }
 
@@ -1049,13 +1075,7 @@ const dbRestoreCongReports = async (
 
     const userRole = settings.user_settings.cong_role;
 
-    const secretaryRole = userRole.includes('secretary');
-    const coordinatorRole = userRole.includes('coordinator');
-    const adminRole =
-      userRole.includes('admin') || secretaryRole || coordinatorRole;
-    const publisherRole = userRole.includes('publisher');
-
-    const allowRestore = adminRole || publisherRole;
+    const allowRestore = canReceiveCongReports(userRole);
 
     if (allowRestore) {
       const remoteData = (
@@ -1638,16 +1658,11 @@ export const dbExportDataBackup = async (backupData: BackupDataType) => {
 
     const { user_settings, cong_settings } = settings;
 
-    const secretaryRole = userRole.includes('secretary');
-    const coordinatorRole = userRole.includes('coordinator');
-    const elderRole = userRole.includes('elder');
-    const groupOverseerRole = userRole.includes('group_overseers');
     const languageGroupOverseerRole = userRole.includes(
       'language_group_overseers'
     );
 
-    const adminRole =
-      userRole.includes('admin') || secretaryRole || coordinatorRole;
+    const adminRole = isAdminRole(userRole);
 
     const serviceCommitteeRole =
       adminRole || userRole.some((role) => role === 'service_overseer');
@@ -1843,10 +1858,7 @@ export const dbExportDataBackup = async (backupData: BackupDataType) => {
 
         // include field service reports
         if (
-          (adminRole ||
-            elderRole ||
-            groupOverseerRole ||
-            languageGroupOverseerRole) &&
+          canSendCongReports(userRole) &&
           metadata.metadata.cong_field_service_reports.send_local
         ) {
           const backupReports = cong_field_service_reports.map((report) => {


### PR DESCRIPTION
Group overseers and language group overseers can open the field service reports page and can send congregation reports up, but they never receive any back. Page loads, sync says it went fine, table stays empty.

It looks like it goes back to f200e6b05 ("feat(app): add two new roles for group overseers"). That commit moved the two gates in opposite directions:

```diff
-    const allowRestore = adminRole || isGroupOverseer || publisherRole;   // incoming
+    const allowRestore = adminRole || publisherRole;

-          (adminRole || isGroupOverseer) &&                               // outgoing
+          (adminRole || elderRole || groupOverseerRole ||
+            languageGroupOverseerRole) &&
```

`isGroupOverseer` was `isAdmin || userRole.includes('group_overseers')` at the time, so incoming lost group overseers, and `language_group_overseers` was never added to incoming at all even though the same commit added it to outgoing and to the route guard in `App.tsx`.

The reason this isn't reported more often is `publisherRole`. That role isn't assignable, `refreshReadOnlyRoles` derives it from `personIsBaptizedPublisher` / `personIsUnbaptizedPublisher`, which need a `publisher_baptized.history` record with a `start_date` covering the current month. Congregations that filled those in mostly pass the check by accident. Congregations that didn't get an empty table with no error.

## Two places, not one

`dbGetMetadata` deletes `cong_field_service_reports` from the version map whenever `!isPublisher`, so the server isn't asked for the table in the first place. Fixing `allowRestore` alone wouldn't have been enough.

Worth mentioning: `dbRestoreCongReports` is the only one of the 15 `dbRestore*` functions in this file that checks roles at all. The other 14 gate purely on `if (!backupData.<table>) return;` and let the metadata map do the work. So arguably `allowRestore` could just be removed to match everything else. I left it in and corrected it instead, since that's the smaller change, but happy to drop it if you'd rather.

## The role predicates

The same role logic was written out by hand in four places, which is how the two gates drifted apart. I pulled the shared part into one helper. I kept send and receive as separate predicates rather than merging them, because they genuinely differ and merging them would have changed behaviour:

```
core     = admin | secretary | coordinator | group_overseers | language_group_overseers
send     = core | elder        (identical to current behaviour)
receive  = core | publisher    (current behaviour plus the two overseer roles)
```

`core` is the same set as the `/reports/field-service` route guard. Merging onto `send` would have started pushing congregation reports to every elder, who has no UI for them and never received them before f200e6b05 either. Merging onto `receive` would have dropped publishers, who are unrelated to this.

Net effect of the whole PR: `group_overseers` and `language_group_overseers` can receive. Outgoing is untouched, nobody loses access.

## Not fixed here

`isPublisher` at the top of the file is `isAdmin || includes('publisher')` while the one inside `dbExportDataBackup` is just `includes('publisher')`. So an admin who isn't a publisher announces `user_field_service_reports` in the metadata but never sends it. Different table, and changing it would make admins start syncing their own bible studies and reports, so I left it alone. Flagging it as a follow-up.

## Testing

No unit tests here and I can't reproduce the sync end to end without two accounts in one congregation on a live backend, so this is code-level only. Lint and build are clean. I worked through the before/after truth table for every role plus combinations: outgoing is unchanged in every case, incoming changes only for the two overseer roles, and no role loses access anywhere.

Would need someone with a real group overseer account to confirm the reports actually land.

Likely fixes #5055, though the reporter never said what roles the affected user had, so I've asked on the issue rather than closing it from here.
