### PR TITLE
feat(persons): add option to skip a person during autofill

### DIFF
--- a/src/constants/table_encryption_map.ts
+++ b/src/constants/table_encryption_map.ts
@@ -12,6 +12,7 @@ export const TABLE_ENCRYPTION_MAP = {
     timeAway: 'shared',
     archived: 'shared',
     disqualified: 'private',
+    autofill_skipped: 'shared',
     email: 'shared',
     address: 'shared',
     phone: 'shared',

--- a/src/definition/person.ts
+++ b/src/definition/person.ts
@@ -92,6 +92,7 @@ export type PersonType = {
     timeAway: TimeAwayType[];
     archived: { value: boolean; updatedAt: string };
     disqualified: { value: boolean; updatedAt: string };
+    autofill_skipped?: { value: boolean; updatedAt: string };
     email: { value: string; updatedAt: string };
     address: { value: string; updatedAt: string };
     phone: { value: string; updatedAt: string };

--- a/src/features/persons/assignments/index.tsx
+++ b/src/features/persons/assignments/index.tsx
@@ -2,6 +2,8 @@ import { Box, Grid } from '@mui/material';
 import { useAppTranslation, useCurrentUser } from '@hooks/index';
 import useAssignments from './useAssignments';
 import AssignmentGroup from '../assignment_group';
+import Divider from '@components/divider';
+import SwitchWithLabel from '@components/switch_with_label';
 import Typography from '@components/typography';
 
 const PersonAssignments = () => {
@@ -17,6 +19,8 @@ const PersonAssignments = () => {
     handleToggleGroup,
     male,
     disqualified,
+    autofillSkipped,
+    handleToggleAutofillSkipped,
   } = useAssignments();
 
   return (
@@ -54,6 +58,16 @@ const PersonAssignments = () => {
           </Grid>
         ))}
       </Grid>
+
+      <Divider color="var(--accent-200)" />
+
+      <SwitchWithLabel
+        label={t('tr_skipDuringAutofill')}
+        helper={t('tr_skipDuringAutofillDesc')}
+        checked={autofillSkipped}
+        onChange={handleToggleAutofillSkipped}
+        readOnly={!isPersonEditor || disqualified}
+      />
     </Box>
   );
 };

--- a/src/features/persons/assignments/useAssignments.tsx
+++ b/src/features/persons/assignments/useAssignments.tsx
@@ -27,6 +27,7 @@ const useAssignments = () => {
 
   const male = person.person_data.male.value;
   const disqualified = person.person_data.disqualified.value;
+  const autofillSkipped = person.person_data.autofill_skipped?.value ?? false;
 
   const duplicateAssignmentsGroup = useMemo(() => {
     return ['ministry'];
@@ -316,6 +317,17 @@ const useAssignments = () => {
     setPersonCurrentDetails(newPerson);
   };
 
+  const handleToggleAutofillSkipped = async (checked: boolean) => {
+    const newPerson = structuredClone(person);
+
+    newPerson.person_data.autofill_skipped = {
+      value: checked,
+      updatedAt: new Date().toISOString(),
+    };
+
+    setPersonCurrentDetails(newPerson);
+  };
+
   const handleToggleAssignment = async (
     checked: boolean,
     code: AssignmentCode
@@ -411,6 +423,8 @@ const useAssignments = () => {
     handleToggleGroup,
     male,
     disqualified,
+    autofillSkipped,
+    handleToggleAutofillSkipped,
     getAssignmentName,
   };
 };

--- a/src/locales/en/congregation.json
+++ b/src/locales/en/congregation.json
@@ -240,6 +240,8 @@
   "tr_assigment": "Assigment",
   "tr_markDisqualifiedDesc": "Disqualified persons cannot participate in meeting parts until re-qualified.",
   "tr_disqualified": "Disqualified",
+  "tr_skipDuringAutofill": "Skip during autofill",
+  "tr_skipDuringAutofillDesc": "Allow assigning meeting parts to this person manually only. Autofill will not select this person.",
   "tr_timeAwayAddedSuccess": "Time away added",
   "tr_timeAwayAddedSuccessDesc": "Thanks for keeping your availability up-to-date",
   "tr_appointSubstituteSpeaker": "Appoint a substitution for visiting speakers",

--- a/src/services/app/persons.ts
+++ b/src/services/app/persons.ts
@@ -999,6 +999,10 @@ export const personGetScheduleName = (person: PersonType) => {
   return result;
 };
 
+export const personSkipsAutofill = (person: PersonType) => {
+  return person.person_data.autofill_skipped?.value === true;
+};
+
 export const personIsAway = (person: PersonType, date: string) => {
   const timeAwaysActive =
     person.person_data.timeAway

--- a/src/services/app/schedules.ts
+++ b/src/services/app/schedules.ts
@@ -88,7 +88,12 @@ import {
   generateDateFromTime,
   timeAddMinutes,
 } from '@utils/date';
-import { applyAssignmentFilters, personIsAway, personIsElder } from './persons';
+import {
+  applyAssignmentFilters,
+  personIsAway,
+  personIsElder,
+  personSkipsAutofill,
+} from './persons';
 import { personsByViewState } from '@states/persons';
 import { personsStateFind } from '@services/states/persons';
 import {
@@ -1704,6 +1709,10 @@ export const schedulesSelectRandomPerson = (data: {
     (record) => !personIsAway(record, meetingDate || data.week)
   );
 
+  personsElligible = personsElligible.filter(
+    (record) => !personSkipsAutofill(record)
+  );
+
   if (data.isElderPart) {
     personsElligible = personsElligible.filter((record) =>
       personIsElder(record)
@@ -1734,7 +1743,7 @@ export const schedulesSelectRandomPerson = (data: {
     personsElligible = applyAssignmentFilters(persons, [
       data.type,
       AssignmentCode.WM_Speaker,
-    ]);
+    ]).filter((record) => !personSkipsAutofill(record));
   }
 
   if (personsElligible.length > 0) {

--- a/src/services/dexie/schema.ts
+++ b/src/services/dexie/schema.ts
@@ -203,6 +203,7 @@ export const personSchema: PersonType = {
     timeAway: [],
     archived: { value: false, updatedAt: '' },
     disqualified: { value: false, updatedAt: '' },
+    autofill_skipped: { value: false, updatedAt: '' },
     email: { value: '', updatedAt: '' },
     address: { value: '', updatedAt: '' },
     phone: { value: '', updatedAt: '' },

--- a/src/states/persons.ts
+++ b/src/states/persons.ts
@@ -55,6 +55,7 @@ export const personCurrentDetailsState = atom<PersonType>({
     timeAway: [],
     archived: { value: false, updatedAt: '' },
     disqualified: { value: false, updatedAt: '' },
+    autofill_skipped: { value: false, updatedAt: '' },
     email: { value: '', updatedAt: '' },
     address: { value: '', updatedAt: '' },
     phone: { value: '', updatedAt: '' },

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -81,6 +81,10 @@ export const importDummyPersons = async (showLoading?: boolean) => {
         person_uid: crypto.randomUUID(),
         person_data: {
           disqualified: { value: false, updatedAt: new Date().toISOString() },
+          autofill_skipped: {
+            value: false,
+            updatedAt: new Date().toISOString(),
+          },
           female: {
             value: user.gender === 'female',
             updatedAt: new Date().toISOString(),


### PR DESCRIPTION
# Description

Some publishers should only take a meeting part when someone picks them for it on purpose, but there was no way to say so. Disqualifying them is too much: it takes away their qualifications and removes them from the manual selectors as well.

A new switch at the bottom of the Assignments card on the person page, **Skip during autofill**, keeps everything as it is and only removes the person from the pool the autofill draws from. Their qualifications stay ticked, every manual selector still offers them, and assignments they already have are untouched.

This is not a qualification, so it does not sit among the qualification checkboxes. It is a scheduling preference: the checkboxes say what a person may do, this switch says how the app fills them in. It is separated from the grid by a divider and reuses the existing `SwitchWithLabel` component.

The autofill draws its candidates in one place, `schedulesSelectRandomPerson`, next to the check that skips people who are away, so one filter covers every midweek and weekend part. The manual selectors build their lists separately and are untouched by design. The switch is read only for users who cannot edit persons, and for a disqualified person, who is already out of everything.

Verified in the app by clearing the same 16 weeks twice and autofilling them again with the same range:

- switch off: 54 student parts filled, the person selected 2 times
- switch on: 54 student parts filled from 37 different students, the person selected 0 times

With the switch on, the person is still offered in the student selector of a midweek part, and the value survives a save and a reload.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sws2apps/organized-app/pull/5400" target="_blank"><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=4"><img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=4" alt="Devin Review"></picture></a>
<!-- devin-review-badge-end -->