### PR TITLE
style(meetings): reduce the meeting section header size

### DIFF
--- a/src/global/global.css
+++ b/src/global/global.css
@@ -666,13 +666,13 @@
   }
 
   .h2-caps {
-    font-size: 18px;
+    font-size: 16px;
     text-decoration: none;
     font-weight: 450;
     font-style: normal;
     font-stretch: normal;
-    letter-spacing: 0.18px;
-    line-height: 22px;
+    letter-spacing: 0.16px;
+    line-height: 20px;
     text-indent: 0px;
     text-transform: uppercase;
   }
@@ -777,13 +777,13 @@
   }
 
   .h2-caps {
-    font-size: 20px;
+    font-size: 18px;
     text-decoration: none;
     font-weight: 450;
     font-style: normal;
     font-stretch: normal;
-    letter-spacing: 0.2px;
-    line-height: 24px;
+    letter-spacing: 0.18px;
+    line-height: 22px;
     text-indent: 0px;
     text-transform: uppercase;
   }


### PR DESCRIPTION
# Description

The uppercase headers that open each meeting section were the largest text on the schedule, a step above the week header they sit under and two steps above the rows they introduce. On a phone the longer ones also pushed their coloured bar onto a second line.

`.h2-caps` is now one step smaller on both breakpoints, with the line height and the letter spacing kept in proportion:

| | before | after |
| --- | --- | --- |
| mobile | 18px / 22 / 0.18 | 16px / 20 / 0.16 |
| desktop | 20px / 24 / 0.20 | 18px / 22 / 0.18 |

Both values land on steps the scale already uses: 16 / 20 is `.h3`, and the new desktop size is what mobile carried before, so no new size was introduced.

The class has four users, all uppercase section headers in the meetings area, and they are meant to move together. Nothing passes `h2-caps` as a prop value, so the union types that list it in `card_header`, `select` and `multi_select` are unaffected.

- `meeting_section` — the coloured bars
- `midweek_editor/week_header` — the week and Bible reading line, which on a phone measured exactly the width available to it and now has room
- `weekly_schedules/outgoing_talks/week_container`
- `sibling_assignments`

Text width was measured against the space a header actually gets on a 375px screen, which is 237px once the icon and its gap are taken off the centred row:

| Header | 18px | 16px | 15px |
| --- | --- | --- | --- |
| LIVING AS CHRISTIANS | 207 | 184 | 173 |
| TREASURES FROM GOD'S WORD | 291 | 258 | 243 |
| APPLY YOURSELF TO THE FIELD MINISTRY | 380 | 338 | 317 |
| UNS IM DIENST VERBESSERN | 262 | 233 | 219 |
| UNSER LEBEN ALS CHRISTEN | 263 | 234 | 219 |

16px brings the German headers and the week header onto one line and shortens the rest. Going to 15px rescues nothing further and reads thin on a saturated bar, so it was left at 16px. The two longest English headers still take two lines on a phone; fitting them on one would need about 12px. The remaining room there is the space the icon takes out of the centred row rather than the size of the text, which would be a change to the section layout and is not part of this.

Checked on the midweek meeting, the weekend meeting and the weekly schedules at 1016px and 375px, with no horizontal scrolling.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
