### PR TITLE
tweak(ui): improve the session list design

### DIFF
--- a/src/features/my_profile/sessions/session_item/index.tsx
+++ b/src/features/my_profile/sessions/session_item/index.tsx
@@ -1,94 +1,179 @@
 import { Box } from '@mui/material';
-import { IconClose, IconComputer, IconPhone } from '@components/icons';
+import {
+  IconClock,
+  IconClose,
+  IconComputer,
+  IconCopy,
+  IconLocation,
+  IconPhone,
+} from '@components/icons';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
 import { SessionItemType } from './index.types';
 import useSessionItem from './useSessionItem';
+import Badge from '@components/badge';
 import Button from '@components/button';
+import Tooltip from '@components/tooltip';
 import Typography from '@components/typography';
+
+const shortenAddress = (value: string) => {
+  if (value.length <= 24) return value;
+
+  return `${value.slice(0, 12)}…${value.slice(-9)}`;
+};
 
 const SessionItem = (props: SessionItemType) => {
   const { t } = useAppTranslation();
 
   const {
     isProcessing,
+    handleCopyAddress,
     handleTerminate,
     isCurrent,
     browser,
     lastSeen,
-    location,
+    country,
+    ip,
   } = useSessionItem(props);
 
   return (
     <Box
       sx={{
         display: 'flex',
-        alignItems: 'center',
-        gap: '16px',
+        alignItems: 'flex-start',
         flexWrap: 'wrap',
-        justifyContent: 'space-between',
+        gap: '8px 12px',
       }}
     >
       <Box
         sx={{
           display: 'flex',
-          alignItems: 'center',
-          gap: '16px',
+          alignItems: 'flex-start',
+          gap: '12px',
           flexGrow: 1,
           minWidth: 0,
+          flexBasis: { mobile: '100%', tablet: 0 },
         }}
       >
         <Box
           sx={{
-            padding: '8px',
+            width: '44px',
+            height: '44px',
             borderRadius: 'var(--radius-l)',
             backgroundColor: 'var(--accent-150)',
             display: 'flex',
-            boxSizing: 'content-box',
+            alignItems: 'center',
+            justifyContent: 'center',
             flexShrink: 0,
           }}
         >
           {props.session.device.isMobile && (
-            <IconPhone height={40} width={40} color="var(--accent-dark)" />
+            <IconPhone height={24} width={24} color="var(--accent-dark)" />
           )}
           {!props.session.device.isMobile && (
-            <IconComputer height={40} width={40} color="var(--accent-dark)" />
+            <IconComputer height={24} width={24} color="var(--accent-dark)" />
           )}
         </Box>
+
         <Box
           sx={{
             display: 'flex',
             flexDirection: 'column',
-            gap: '4px',
-            flexGrow: 1,
+            gap: '6px',
             minWidth: 0,
           }}
         >
-          <Typography
-            className="body-small-regular"
-            color="var(--accent-400)"
-            sx={{ wordBreak: 'break-word' }}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: '8px',
+            }}
           >
-            {location}
-          </Typography>
-          <Typography className="body-small-regular" color="var(--accent-400)">
-            {browser}
-          </Typography>
-          <Typography className="body-small-regular" color="var(--accent-400)">
-            {lastSeen}
-          </Typography>
+            <Typography className="body-small-semibold">{browser}</Typography>
+
+            {isCurrent && (
+              <Badge
+                size="small"
+                color="green"
+                text={t('tr_currentSession')}
+                className="body-small-regular"
+              />
+            )}
+          </Box>
+
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: '6px',
+            }}
+          >
+            {country.length > 0 && (
+              <Badge
+                size="small"
+                color="grey"
+                text={country}
+                icon={<IconLocation />}
+                className="body-small-regular"
+              />
+            )}
+
+            {lastSeen.length > 0 && (
+              <Badge
+                size="small"
+                color="grey"
+                text={lastSeen}
+                icon={<IconClock />}
+                className="body-small-regular"
+              />
+            )}
+
+            <Tooltip title={ip} placement="top">
+              <Box
+                component="button"
+                onClick={handleCopyAddress}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  height: '20px',
+                  padding: '2px 6px',
+                  cursor: 'pointer',
+                  border: 'none',
+                  borderRadius: 'var(--radius-xs)',
+                  backgroundColor: 'var(--grey-150)',
+                  color: 'var(--grey-400)',
+                  '&:hover': { backgroundColor: 'var(--accent-200)' },
+                  '& svg': { height: '14px', width: '14px' },
+                  '& svg, & svg g, & svg g path': { fill: 'var(--grey-400)' },
+                }}
+              >
+                <Typography className="body-small-regular" color="inherit">
+                  {shortenAddress(ip)}
+                </Typography>
+                <IconCopy />
+              </Box>
+            </Tooltip>
+          </Box>
         </Box>
       </Box>
-      <Button
-        variant="secondary"
-        color={isCurrent ? 'green' : 'red'}
-        startIcon={
-          isCurrent ? null : isProcessing ? <IconLoading /> : <IconClose />
-        }
-        onClick={isCurrent ? null : handleTerminate}
-      >
-        {isCurrent ? t('tr_currentSession') : t('tr_terminate')}
-      </Button>
+
+      {!isCurrent && (
+        <Button
+          variant="small"
+          color="red"
+          disableAutoStretch
+          minHeight={28}
+          startIcon={isProcessing ? <IconLoading /> : <IconClose />}
+          onClick={handleTerminate}
+          sx={{ flexShrink: 0, marginLeft: 'auto' }}
+        >
+          {t('tr_terminate')}
+        </Button>
+      )}
     </Box>
   );
 };

--- a/src/features/my_profile/sessions/session_item/index.tsx
+++ b/src/features/my_profile/sessions/session_item/index.tsx
@@ -132,30 +132,27 @@ const SessionItem = (props: SessionItemType) => {
             )}
 
             <Tooltip title={ip} placement="top">
-              <Box
-                component="button"
+              <Button
+                variant="small"
+                disableAutoStretch
+                minHeight={20}
+                ariaLabel={`${t('tr_copy')}: ${ip}`}
+                endIcon={<IconCopy />}
                 onClick={handleCopyAddress}
                 sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '4px',
-                  height: '20px',
                   padding: '2px 6px',
-                  cursor: 'pointer',
-                  border: 'none',
                   borderRadius: 'var(--radius-xs)',
                   backgroundColor: 'var(--grey-150)',
                   color: 'var(--grey-400)',
-                  '&:hover': { backgroundColor: 'var(--accent-200)' },
+                  fontWeight: 400,
+                  '& .MuiButton-endIcon': { marginLeft: '4px' },
                   '& svg': { height: '14px', width: '14px' },
                   '& svg, & svg g, & svg g path': { fill: 'var(--grey-400)' },
+                  '&:hover': { backgroundColor: 'var(--accent-200)' },
                 }}
               >
-                <Typography className="body-small-regular" color="inherit">
-                  {shortenAddress(ip)}
-                </Typography>
-                <IconCopy />
-              </Box>
+                {shortenAddress(ip)}
+              </Button>
             </Tooltip>
           </Box>
         </Box>

--- a/src/features/my_profile/sessions/session_item/useSessionItem.tsx
+++ b/src/features/my_profile/sessions/session_item/useSessionItem.tsx
@@ -6,6 +6,7 @@ import { getMessageByCode } from '@services/i18n/translation';
 import { SessionItemType } from './index.types';
 import { hour24FormatState, shortDateFormatState } from '@states/settings';
 import { formatLongDate } from '@utils/date';
+import { copyToClipboard } from '@utils/common';
 
 const useSessionItem = ({ onTerminate, session }: SessionItemType) => {
   const { t } = useAppTranslation();
@@ -15,9 +16,28 @@ const useSessionItem = ({ onTerminate, session }: SessionItemType) => {
 
   const [isProcessing, setIsProcessing] = useState(false);
   const [isCurrent, setIsCurrent] = useState(false);
-  const [location, setLocation] = useState('');
+  const [country, setCountry] = useState('');
+  const [ip, setIp] = useState('');
   const [browser, setBrowser] = useState('');
   const [lastSeen, setLastSeen] = useState('');
+
+  const handleCopyAddress = async () => {
+    try {
+      await copyToClipboard(session.ip);
+
+      displaySnackNotification({
+        header: t('tr_textCopied'),
+        message: '',
+        severity: 'success',
+      });
+    } catch (error) {
+      displaySnackNotification({
+        header: getMessageByCode('error_app_generic-title'),
+        message: getMessageByCode((error as Error).message),
+        severity: 'error',
+      });
+    }
+  };
 
   const handleTerminate = async () => {
     if (isProcessing) return;
@@ -42,11 +62,8 @@ const useSessionItem = ({ onTerminate, session }: SessionItemType) => {
   useEffect(() => {
     setIsCurrent(session.isSelf);
 
-    setLocation(session.ip);
-
-    if (session.country_name.length > 0) {
-      setLocation((prev) => `${prev} - ${session.country_name}`);
-    }
+    setCountry(session.country_name);
+    setIp(session.ip);
 
     setBrowser(session.device.browserName);
 
@@ -61,14 +78,16 @@ const useSessionItem = ({ onTerminate, session }: SessionItemType) => {
       tmpDate = formatLongDate(toFormat, shortDateFormat, hour24);
     }
 
-    setLastSeen(tmpDate.length > 0 ? t('tr_lastSeen', { date: tmpDate }) : '');
+    setLastSeen(tmpDate);
   }, [session, t, hour24, shortDateFormat]);
 
   return {
     isProcessing,
+    handleCopyAddress,
     handleTerminate,
     isCurrent,
-    location,
+    country,
+    ip,
     browser,
     lastSeen,
   };


### PR DESCRIPTION
Each session is now a device row: a square icon tile, the device name with a badge for the current session, and the location, last seen time and IP address as compact chips.

Long IPv6 addresses are shortened in the middle, shown in full on hover, and copied to the clipboard when the chip is clicked. Terminate uses the small button and moves under the details on narrow screens.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sws2apps/organized-app/pull/5404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->