### PR TITLE
tweak(ui): rework the page and pane animations

### DIFF
--- a/src/components/page_transition/index.tsx
+++ b/src/components/page_transition/index.tsx
@@ -1,0 +1,20 @@
+import { PropsWithChildren } from 'react';
+import { Box } from '@mui/material';
+import { useLocation } from 'react-router';
+
+/**
+ * Component that fades a page in when the route changes.
+ * @param {PropsWithChildren} props - Props for the PageTransition component.
+ * @returns {JSX.Element} PageTransition component.
+ */
+const PageTransition = ({ children }: PropsWithChildren) => {
+  const { pathname } = useLocation();
+
+  return (
+    <Box key={pathname} className="page-transition">
+      {children}
+    </Box>
+  );
+};
+
+export default PageTransition;

--- a/src/components/pane_switcher/index.tsx
+++ b/src/components/pane_switcher/index.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Box } from '@mui/material';
+import { PaneSwitcherProps } from './index.types';
+
+const SWITCH_DURATION = 260;
+
+// panes slide out by their own width, plus the page padding when they are
+// allowed to leave the container, so they clear the edge of the screen
+const getPaneOffset = (distance: number, fullBleed?: boolean) => {
+  if (distance === 0) return 'none';
+
+  const padding = fullBleed ? ` + ${distance} * var(--page-padding)` : '';
+
+  return `translateX(calc(${distance * 100}%${padding}))`;
+};
+
+/**
+ * Component that slides between panes that share the same spot on a page.
+ * @param {PaneSwitcherProps} props - Props for the PaneSwitcher component.
+ * @returns {JSX.Element} PaneSwitcher component.
+ */
+const PaneSwitcher = ({ panes, value, fullBleed, sx }: PaneSwitcherProps) => {
+  const paneRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  const [height, setHeight] = useState<number>();
+  const [isSwitching, setIsSwitching] = useState(false);
+
+  useLayoutEffect(() => {
+    const pane = paneRefs.current[value];
+
+    if (!pane) return;
+
+    const observer = new ResizeObserver(() => {
+      setHeight(pane.offsetHeight);
+    });
+
+    observer.observe(pane);
+
+    return () => observer.disconnect();
+  }, [value]);
+
+  // while the panes slide past each other both of them need their full height,
+  // otherwise the taller one gets cut in the middle of the animation
+  useLayoutEffect(() => {
+    setIsSwitching(true);
+
+    const timer = setTimeout(() => setIsSwitching(false), SWITCH_DURATION);
+
+    return () => clearTimeout(timer);
+  }, [value]);
+
+  const paneHeights = paneRefs.current.map((pane) => pane?.offsetHeight ?? 0);
+
+  const containerHeight = isSwitching
+    ? Math.max(height ?? 0, ...paneHeights)
+    : height;
+
+  useEffect(() => {
+    for (const [index, pane] of paneRefs.current.entries()) {
+      if (!pane) continue;
+
+      pane.inert = index !== value;
+    }
+  }, [value, panes.length]);
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        overflow: 'clip',
+        width: '100%',
+        height: containerHeight ? `${containerHeight}px` : 'auto',
+        ...(fullBleed && {
+          width: 'calc(100% + var(--page-padding) * 2)',
+          marginInline: 'calc(var(--page-padding) * -1)',
+          paddingInline: 'var(--page-padding)',
+        }),
+        ...sx,
+      }}
+    >
+      {panes.map((pane, index) => (
+        <Box
+          key={pane.key}
+          ref={(element: HTMLDivElement | null) => {
+            paneRefs.current[index] = element;
+          }}
+          aria-hidden={index !== value}
+          sx={{
+            gridArea: '1 / 1',
+            alignSelf: 'start',
+            opacity: index === value ? 1 : 0,
+            transform: getPaneOffset(index - value, fullBleed),
+            transition:
+              'transform var(--motion-base) var(--ease-standard), opacity var(--motion-fast) var(--ease-standard)',
+            '@media (prefers-reduced-motion: reduce)': {
+              transform: 'none',
+              transition: 'none',
+              visibility: index === value ? 'visible' : 'hidden',
+            },
+          }}
+        >
+          {pane.content}
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export default PaneSwitcher;

--- a/src/components/pane_switcher/index.tsx
+++ b/src/components/pane_switcher/index.tsx
@@ -2,7 +2,8 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Box } from '@mui/material';
 import { PaneSwitcherProps } from './index.types';
 
-const SWITCH_DURATION = 260;
+// mirrors the --motion-base token the panes animate with
+const SWITCH_DURATION = 240;
 
 // panes slide out by their own width, plus the page padding when they are
 // allowed to leave the container, so they clear the edge of the screen
@@ -24,6 +25,7 @@ const PaneSwitcher = ({ panes, value, fullBleed, sx }: PaneSwitcherProps) => {
 
   const [height, setHeight] = useState<number>();
   const [isSwitching, setIsSwitching] = useState(false);
+  const isFirstValue = useRef(true);
 
   useLayoutEffect(() => {
     const pane = paneRefs.current[value];
@@ -42,6 +44,13 @@ const PaneSwitcher = ({ panes, value, fullBleed, sx }: PaneSwitcherProps) => {
   // while the panes slide past each other both of them need their full height,
   // otherwise the taller one gets cut in the middle of the animation
   useLayoutEffect(() => {
+    // nothing slides on mount, so reserving the tallest pane would only make
+    // the page jump once the reservation ends
+    if (isFirstValue.current) {
+      isFirstValue.current = false;
+      return;
+    }
+
     setIsSwitching(true);
 
     const timer = setTimeout(() => setIsSwitching(false), SWITCH_DURATION);

--- a/src/components/pane_switcher/index.types.ts
+++ b/src/components/pane_switcher/index.types.ts
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+import { SxProps, Theme } from '@mui/material';
+
+/**
+ * Props type for the PaneSwitcher component.
+ */
+export type PaneSwitcherProps = {
+  /**
+   * Panes to switch between, in the order they are laid out.
+   */
+  panes: { key: string; content: ReactNode }[];
+
+  /**
+   * Index of the pane to show.
+   */
+  value: number;
+
+  /**
+   * Lets the panes slide out to the edge of the screen instead of the edge of
+   * the page container.
+   */
+  fullBleed?: boolean;
+
+  /**
+   * Custom styles for the container.
+   */
+  sx?: SxProps<Theme>;
+};

--- a/src/global/index.css
+++ b/src/global/index.css
@@ -177,3 +177,45 @@ span .text-markup:last-child {
 body iframe {
   opacity: 0;
 }
+
+/* page paddings, kept in sync with the container of the root layout */
+:root {
+  --page-padding: 16px;
+}
+
+@media (min-width: 480px) {
+  :root {
+    --page-padding: 24px;
+  }
+}
+
+@media (min-width: 1200px) {
+  :root {
+    --page-padding: 32px;
+  }
+}
+
+/* shared motion tokens */
+:root {
+  --motion-fast: 180ms;
+  --motion-base: 240ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* page to page transitions */
+.page-transition {
+  animation: page-enter var(--motion-base) var(--ease-standard) both;
+}
+
+@keyframes page-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-transition {
+    animation: none;
+  }
+}

--- a/src/layouts/root_layout/index.tsx
+++ b/src/layouts/root_layout/index.tsx
@@ -12,6 +12,7 @@ import useRootLayout from './useRootLayout';
 import About from '@features/about';
 import AppFeedback from '@features/app_feedback';
 import AppReminders from '@features/reminders';
+import PageTransition from '@components/page_transition';
 import AppUpdater from '@features/app_updater';
 import Contact from '@features/contact';
 import DashboardSkeletonLoader from '@features/dashboard/skeleton_loader';
@@ -70,8 +71,7 @@ const RootLayout = ({ updatePwa }: { updatePwa: VoidFunction }) => {
           sx={{
             maxWidth: '1440px',
             width: '100%',
-            paddingLeft: { mobile: '16px', tablet: '24px', desktop: '32px' },
-            paddingRight: { mobile: '16px', tablet: '24px', desktop: '32px' },
+            paddingInline: 'var(--page-padding)',
             marginTop: '24px',
           }}
         >
@@ -108,7 +108,9 @@ const RootLayout = ({ updatePwa }: { updatePwa: VoidFunction }) => {
 
                   <Box sx={{ marginBottom: '32px' }}>
                     <MyAssignments />
-                    <Outlet />
+                    <PageTransition>
+                      <Outlet />
+                    </PageTransition>
                   </Box>
                 </Suspense>
               )}

--- a/src/pages/persons/all_persons/index.tsx
+++ b/src/pages/persons/all_persons/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Slide } from '@mui/material';
+import { Box } from '@mui/material';
 import { Button, PageTitle } from '@components/index';
 import {
   IconAddPerson,
@@ -19,6 +19,7 @@ import PersonsSearch from '@features/persons/search';
 import NavBarButton from '@components/nav_bar_button';
 import NavBarButtonGroup from '@components/nav_bar_button_group';
 import ImportExport from '@features/persons/import_export';
+import PaneSwitcher from '@components/pane_switcher';
 
 const PersonsAll = () => {
   const { t } = useAppTranslation();
@@ -35,6 +36,46 @@ const PersonsAll = () => {
     isDataExchangeOpen,
     handleCloseExchange,
   } = useAllPersons();
+
+  const listCardStyles = {
+    backgroundColor: 'var(--white)',
+    border: '1px solid var(--accent-300)',
+    flex: 1,
+    borderRadius: 'var(--radius-xl)',
+    padding: '16px',
+    display: 'flex',
+    gap: '16px',
+    flexDirection: 'column',
+  };
+
+  const filterCardStyles = {
+    backgroundColor: 'var(--white)',
+    border: '1px solid var(--accent-300)',
+    borderRadius: 'var(--radius-xl)',
+    padding: '16px',
+    width: '100%',
+  };
+
+  const listPane = (
+    <>
+      <Box sx={{ display: 'flex', gap: '16px', alignItems: 'flex-start' }}>
+        <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+          <PersonsSearch />
+        </Box>
+        <Button
+          variant="secondary"
+          disableAutoStretch
+          sx={{ flexShrink: 0, height: '48px', padding: '8px 16px' }}
+          onClick={() => setIsPanelOpen((prev) => !prev)}
+          endIcon={isPanelOpen ? <IconPanelOpen /> : <IconPanelClose />}
+        >
+          {t('tr_filters')}
+        </Button>
+      </Box>
+
+      <PersonsList />
+    </>
+  );
 
   return (
     <Box
@@ -77,118 +118,31 @@ const PersonsAll = () => {
           alignItems: 'flex-start',
         }}
       >
-        {desktopUp && (
-          <Box
-            sx={{
-              backgroundColor: 'var(--white)',
-              border: '1px solid var(--accent-300)',
-              flex: 1,
-              borderRadius: 'var(--radius-xl)',
-              padding: '16px',
-              display: 'flex',
-              gap: '16px',
-              flexDirection: 'column',
-            }}
-          >
-            <Box sx={{ display: 'flex', gap: '16px', alignItems: 'flex-start' }}>
-              <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                <PersonsSearch />
-              </Box>
-              <Button
-                variant="secondary"
-                disableAutoStretch
-                sx={{ flexShrink: 0, height: '48px', padding: '8px 16px' }}
-                onClick={() => setIsPanelOpen((prev) => !prev)}
-                endIcon={isPanelOpen ? <IconPanelOpen /> : <IconPanelClose />}
-              >
-                {t('tr_filters')}
-              </Button>
-            </Box>
-
-            <PersonsList />
-          </Box>
-        )}
+        {desktopUp && <Box sx={listCardStyles}>{listPane}</Box>}
 
         {!desktopUp && (
-          <Box sx={{ position: 'relative', overflowX: 'clip', width: '100%' }}>
-            <Slide direction="right" in={!isPanelOpen} unmountOnExit>
-              <Box
-                sx={{
-                  position: 'absolute',
-                  left: 0,
-                  right: 0,
-                  paddingBottom: '32px',
-                }}
-              >
-                <Box
-                  sx={{
-                    backgroundColor: 'var(--white)',
-                    border: '1px solid var(--accent-300)',
-                    flex: 1,
-                    borderRadius: 'var(--radius-xl)',
-                    padding: '16px',
-                    display: 'flex',
-                    gap: '16px',
-                    flexDirection: 'column',
-                  }}
-                >
-                  <Box sx={{ display: 'flex', gap: '16px', alignItems: 'flex-start' }}>
-                    <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                      <PersonsSearch />
-                    </Box>
-                    <Button
-                      variant="secondary"
-                      disableAutoStretch
-                      sx={{ flexShrink: 0, height: '48px', padding: '8px 16px' }}
-                      onClick={() => setIsPanelOpen((prev) => !prev)}
-                      endIcon={
-                        isPanelOpen ? <IconPanelOpen /> : <IconPanelClose />
-                      }
-                    >
-                      {t('tr_filters')}
-                    </Button>
+          <PaneSwitcher
+            fullBleed
+            value={isPanelOpen ? 1 : 0}
+            panes={[
+              {
+                key: 'list',
+                content: <Box sx={listCardStyles}>{listPane}</Box>,
+              },
+              {
+                key: 'filter',
+                content: (
+                  <Box sx={filterCardStyles}>
+                    <PersonsFilter />
                   </Box>
-
-                  <PersonsList />
-                </Box>
-              </Box>
-            </Slide>
-
-            <Slide direction="left" in={isPanelOpen} unmountOnExit>
-              <Box
-                sx={{
-                  position: 'absolute',
-                  left: 0,
-                  right: 0,
-                  paddingBottom: '32px',
-                }}
-              >
-                <Box
-                  sx={{
-                    backgroundColor: 'var(--white)',
-                    border: '1px solid var(--accent-300)',
-                    borderRadius: 'var(--radius-xl)',
-                    padding: '16px',
-                    width: '100%',
-                  }}
-                >
-                  <PersonsFilter />
-                </Box>
-              </Box>
-            </Slide>
-          </Box>
+                ),
+              },
+            ]}
+          />
         )}
 
         {desktopUp && isPanelOpen && (
-          <Box
-            sx={{
-              backgroundColor: 'var(--white)',
-              border: '1px solid var(--accent-300)',
-              borderRadius: 'var(--radius-xl)',
-              padding: '16px',
-              width: '520px',
-            }}
-          >
+          <Box sx={{ ...filterCardStyles, width: '520px' }}>
             <PersonsFilter />
           </Box>
         )}


### PR DESCRIPTION
On mobile the persons page put both panes in `position: absolute`, so the wrapper measured 0px tall and the sliding cards were cut 16px inside each screen edge. Opening a person had no animation at all, while going back replayed that same cropped slide.

Two reusable pieces replace it:

- `PaneSwitcher` — slides between panes that share a spot on a page. The panes stay in the layout flow, so the container keeps a real height, and they slide out to the edge of the screen instead of the page padding. Used by the persons list and filters.
- `PageTransition` — fades a page in on route change, so opening a person and going back look the same on every page.

Both use shared motion tokens and stop animating under reduced motion. The page padding became a variable so the container and the animations cannot drift apart.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sws2apps/organized-app/pull/5407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->