### PR TITLE
tweak(persons): show the person name under the page title

### DIFF
--- a/src/pages/persons/person_details/index.tsx
+++ b/src/pages/persons/person_details/index.tsx
@@ -25,7 +25,8 @@ const PersonDetails = () => {
 
   const { isAdmin } = useCurrentUser();
 
-  const { isNewPerson, isBaptized, male, isConnected } = usePersonDetails();
+  const { isNewPerson, isBaptized, male, isConnected, personName } =
+    usePersonDetails();
 
   return (
     <Box
@@ -38,6 +39,7 @@ const PersonDetails = () => {
     >
       <PageTitle
         title={isNewPerson ? t('tr_addNewPerson') : t('tr_editPerson')}
+        secondaryTitle={isNewPerson ? undefined : personName}
         buttons={<PersonButtonActions />}
       />
 

--- a/src/pages/persons/person_details/usePersonDetails.tsx
+++ b/src/pages/persons/person_details/usePersonDetails.tsx
@@ -23,13 +23,21 @@ const usePersonDetails = () => {
     return person.person_data.publisher_baptized.active.value;
   }, [person]);
 
+  // the shared record may still hold the previously opened person until the
+  // effect below replaces it, so the title is read from the route instead
   const personName = useMemo(() => {
+    const record = isNewPerson
+      ? person
+      : persons.find((item) => item.person_uid === id);
+
+    if (!record) return '';
+
     return buildPersonFullname(
-      person.person_data.person_lastname.value,
-      person.person_data.person_firstname.value,
+      record.person_data.person_lastname.value,
+      record.person_data.person_firstname.value,
       fullnameOption
     );
-  }, [person, fullnameOption]);
+  }, [id, isNewPerson, person, persons, fullnameOption]);
 
   const male = useMemo(() => {
     return person.person_data.male.value;

--- a/src/pages/persons/person_details/usePersonDetails.tsx
+++ b/src/pages/persons/person_details/usePersonDetails.tsx
@@ -4,6 +4,8 @@ import { useAtom, useAtomValue } from 'jotai';
 import { personCurrentDetailsState, personsState } from '@states/persons';
 import { personSchema } from '@services/dexie/schema';
 import { congAccountConnectedState } from '@states/app';
+import { fullnameOptionState } from '@states/settings';
+import { buildPersonFullname } from '@utils/common';
 
 const usePersonDetails = () => {
   const { id } = useParams();
@@ -15,10 +17,19 @@ const usePersonDetails = () => {
 
   const persons = useAtomValue(personsState);
   const isConnected = useAtomValue(congAccountConnectedState);
+  const fullnameOption = useAtomValue(fullnameOptionState);
 
   const isBaptized = useMemo(() => {
     return person.person_data.publisher_baptized.active.value;
   }, [person]);
+
+  const personName = useMemo(() => {
+    return buildPersonFullname(
+      person.person_data.person_lastname.value,
+      person.person_data.person_firstname.value,
+      fullnameOption
+    );
+  }, [person, fullnameOption]);
 
   const male = useMemo(() => {
     return person.person_data.male.value;
@@ -45,7 +56,7 @@ const usePersonDetails = () => {
     }
   }, [id, persons, navigate, isNewPerson, setPerson]);
 
-  return { isNewPerson, isBaptized, male, isConnected };
+  return { isNewPerson, isBaptized, male, isConnected, personName };
 };
 
 export default usePersonDetails;


### PR DESCRIPTION
The person page had only "Edit person" in the header, with no hint of who is being edited.

It now uses the existing two-line page title: "Edit person" with the person name under it, the same variant the field service reports page already uses. Adding a new person keeps the plain title.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sws2apps/organized-app/pull/5408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->