### PR TITLE
tweak(ui): centre the navbar title on mobile

### DIFF
--- a/src/layouts/navbar/index.tsx
+++ b/src/layouts/navbar/index.tsx
@@ -531,7 +531,8 @@ const NavBar = ({ isSupported }: NavBarType) => {
                     sx={{
                       display: 'flex',
                       flexDirection: 'column',
-                      marginLeft: '-8px',
+                      marginLeft: tablet688Up ? '-8px' : 0,
+                      alignItems: tablet688Up ? 'flex-start' : 'center',
                     }}
                   >
                     <Typography
@@ -541,6 +542,7 @@ const NavBar = ({ isSupported }: NavBarType) => {
                         whiteSpace: 'nowrap',
                         textOverflow: 'ellipsis',
                         overflow: 'hidden',
+                        textAlign: tablet688Up ? 'start' : 'center',
                       }}
                     >
                       {navBarOptions.title}
@@ -552,6 +554,7 @@ const NavBar = ({ isSupported }: NavBarType) => {
                         whiteSpace: 'nowrap',
                         textOverflow: 'ellipsis',
                         overflow: 'hidden',
+                        textAlign: tablet688Up ? 'start' : 'center',
                       }}
                     >
                       {navBarOptions.secondaryTitle}
@@ -588,7 +591,7 @@ const NavBar = ({ isSupported }: NavBarType) => {
                     </IconButton>
                   ) : (
                     !tablet688Up && (
-                      <Box sx={{ width: '22px', height: '22px' }} />
+                      <Box sx={{ width: '40px', height: '40px' }} />
                     )
                   )}
                 </Box>


### PR DESCRIPTION
On a phone the page title and the line under it sat next to the back arrow instead of in the middle of the bar, so pages like the filters, publisher records and field service reports all read off-centre.

They are now centred there, and still read from the start of the bar on wider screens. The change is the same one made to the navbar in #5224, kept identical so the two do not conflict.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)