### PR TITLE
fix(sync): restore congregation reports for overseers and assistants

### DIFF
--- a/src/indexedDb/appDb.ts
+++ b/src/indexedDb/appDb.ts
@@ -182,6 +182,31 @@ appDb.version(12).stores({
   ...upcomingEventsSchema,
 });
 
+appDb
+  .version(13)
+  .stores({
+    ...schema,
+    ...metadataSchema,
+    ...delegatedFieldServiceReportsSchema,
+    ...weekTypeSchema,
+    ...publicTalkSchema,
+    ...songSchema,
+    ...upcomingEventsSchema,
+  })
+  .upgrade(async (tx) => {
+    // congregation reports were dropped on restore for elders and group
+    // overseers (including assistants, who share those roles) while their
+    // version kept advancing: clear it once so the next sync pulls the
+    // reports they never received instead of trusting a stale version
+    const record = await tx.table('metadata').get(1);
+
+    if (!record?.metadata?.cong_field_service_reports) return;
+
+    record.metadata.cong_field_service_reports.version = '';
+
+    await tx.table('metadata').put(record);
+  });
+
 appDb.on('populate', function () {
   appDb.app_settings.add(settingSchema);
 });

--- a/src/services/worker/backupUtils.ts
+++ b/src/services/worker/backupUtils.ts
@@ -9,6 +9,7 @@ import {
   encryptObject,
   generateKey,
 } from '@services/encryption';
+import { AppRoleType } from '@definition/app';
 import { PersonType, PrivilegeType } from '@definition/person';
 import {
   OutgoingTalkExportScheduleType,
@@ -231,6 +232,24 @@ export const dbGetSettings = async () => {
   return settings;
 };
 
+// congregation reports are readable and writable by the same roles on the API,
+// so every gate in this file must resolve them the same way.
+// Service group assistants share the group_overseers / language_group_overseers
+// roles (see refreshReadOnlyRoles), so they are covered transitively here.
+const isReportEditorRole = (userRole: AppRoleType[]) => {
+  const adminRole =
+    userRole.includes('admin') ||
+    userRole.includes('secretary') ||
+    userRole.includes('coordinator');
+
+  return (
+    adminRole ||
+    userRole.includes('elder') ||
+    userRole.includes('group_overseers') ||
+    userRole.includes('language_group_overseers')
+  );
+};
+
 export const isMondayDate = (date: string) => {
   const inputDate = new Date(date);
   const dayOfWeek = inputDate.getDay();
@@ -278,10 +297,15 @@ export const dbGetMetadata = async () => {
   const isAttendanceTracker =
     isAdmin || userRole.some((role) => role === 'attendance_tracking');
 
+  const isReportEditor = isReportEditorRole(userRole);
+
   if (!isPublisher) {
     delete result.user_bible_studies;
     delete result.user_field_service_reports;
     delete result.delegated_field_service_reports;
+  }
+
+  if (!isPublisher && !isReportEditor) {
     delete result.cong_field_service_reports;
   }
 
@@ -1049,13 +1073,9 @@ const dbRestoreCongReports = async (
 
     const userRole = settings.user_settings.cong_role;
 
-    const secretaryRole = userRole.includes('secretary');
-    const coordinatorRole = userRole.includes('coordinator');
-    const adminRole =
-      userRole.includes('admin') || secretaryRole || coordinatorRole;
     const publisherRole = userRole.includes('publisher');
 
-    const allowRestore = adminRole || publisherRole;
+    const allowRestore = isReportEditorRole(userRole) || publisherRole;
 
     if (allowRestore) {
       const remoteData = (
@@ -1640,8 +1660,6 @@ export const dbExportDataBackup = async (backupData: BackupDataType) => {
 
     const secretaryRole = userRole.includes('secretary');
     const coordinatorRole = userRole.includes('coordinator');
-    const elderRole = userRole.includes('elder');
-    const groupOverseerRole = userRole.includes('group_overseers');
     const languageGroupOverseerRole = userRole.includes(
       'language_group_overseers'
     );
@@ -1843,10 +1861,7 @@ export const dbExportDataBackup = async (backupData: BackupDataType) => {
 
         // include field service reports
         if (
-          (adminRole ||
-            elderRole ||
-            groupOverseerRole ||
-            languageGroupOverseerRole) &&
+          isReportEditorRole(userRole) &&
           metadata.metadata.cong_field_service_reports.send_local
         ) {
           const backupReports = cong_field_service_reports.map((report) => {


### PR DESCRIPTION
# Description

Service group assistants get the same group_overseers role as overseers (refreshReadOnlyRoles), so they could upload cong_field_service_reports but never restore it: the restore gate only allowed admin/publisher and the metadata request dropped the table version for non-publishers. Their local version kept advancing without data, and stale uploads then 409-looped (error_api_sync-conflict), blocking all sync including their own reports.

Fixes #5064

Resolves the report-editor roles once in isReportEditorRole and uses it for the restore gate, the export gate and the metadata sent to the API, so the three can no longer drift. Assistants are covered transitively through group_overseers / language_group_overseers. Clears the stale cong_field_service_reports version once on DB upgrade so affected clients re-pull on next sync.

Note: overlaps with #5382 (same helper approach). Happy to close this in favour of #5382 if preferred -- opening separately so #5064 has a linked fix with the assistant analysis and verification.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sws2apps/organized-app/pull/5415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->