### PR TITLE
fix(features): keep release notes hidden until their release date

### DIFF
--- a/src/features/whats_new/useWhatsNew.tsx
+++ b/src/features/whats_new/useWhatsNew.tsx
@@ -26,14 +26,21 @@ const useWhatsNew = () => {
   }, [i18n]);
 
   const version = useMemo(() => {
-    const releasesDates = Object.keys(releases);
-    return releasesDates.sort().reverse().at(0);
+    // notes for a release still to come are already translated, but announcing
+    // them before that date would describe an app the user does not have yet
+    const today = new Date().toISOString().slice(0, 16);
+
+    return Object.keys(releases)
+      .filter((releaseDate) => releaseDate <= today)
+      .sort()
+      .reverse()
+      .at(0);
   }, [releases]);
 
   const handleClose = () => {
     setOpen(false);
 
-    if (!isTest) {
+    if (!isTest && version) {
       const saved = localStorage.getItem(STORAGE_KEY);
       const lsVersion = (saved ? JSON.parse(saved) : {}) as UpdateStatusType;
 
@@ -67,6 +74,9 @@ const useWhatsNew = () => {
 
   useEffect(() => {
     const checkReleaseNotes = () => {
+      // every release is still ahead: nothing to announce on this device
+      if (!version) return;
+
       let showUpdate = true;
 
       const tmp = localStorage.getItem(STORAGE_KEY);
@@ -79,7 +89,7 @@ const useWhatsNew = () => {
       }
 
       if (showUpdate) {
-        const { improvements, images } = releases[version] || releases['next'];
+        const { improvements, images } = releases[version];
 
         if (improvements) {
           const formattedImprovements = Object.values(improvements);


### PR DESCRIPTION
The what's new dialog shows the highest-sorting key in `release_notes.json`, with no comparison against today. Two consequences: notes added ahead of a release are announced at the next deploy, and the legacy `"next"` placeholder outranks every dated entry (`n` sorts above `2`), so it would show immediately.

Entries dated in the future are now filtered out, and the dialog stays closed when every release is still ahead. This lets an upcoming release be merged early so Crowdin picks the strings up and translators can start, without the notes reaching users before the release itself.

Behaviour for the current entries is unchanged. Verified the selection against past, future, boundary and `next` keys, and this file now reports 5 fewer TypeScript errors than on main.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sws2apps/organized-app/pull/5419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->