### PR TITLE
tweak(ui): keep pop-up dialog title and buttons accessible while scrolling content

### DIFF
--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -5,17 +5,18 @@ import {
   PropsWithChildren,
   ReactNode,
 } from 'react';
-import { Box, Dialog as MUIDialog, DialogContent } from '@mui/material';
+import { Box, Dialog as MUIDialog, DialogContent, Stack } from '@mui/material';
+import { ResponsiveStyleValue } from '@mui/system';
 import DialogActions from '@components/dialog_actions';
-import { useScrollFade } from '@hooks/index';
+import IconButton from '@components/icon_button';
+import Typography from '@components/typography';
+import { IconClose } from '@components/icons';
+import { useAppTranslation, useScrollFade } from '@hooks/index';
 import { DialogProps } from './index.types';
 
-const DEFAULT_PADDING = { mobile: '16px', desktop: '32px' };
+const DEFAULT_PADDING = '24px';
 
-/**
- * Flattens fragments, so an actions row a caller wrapped in one is still
- * recognised as a child of the dialog.
- */
+// fragments are flattened, so an actions row wrapped in one is still found
 const flatten = (children: ReactNode): ReactNode[] =>
   Children.toArray(children).flatMap((child) =>
     isValidElement(child) && child.type === Fragment
@@ -26,39 +27,23 @@ const flatten = (children: ReactNode): ReactNode[] =>
 const isActionsRow = (child: ReactNode) =>
   isValidElement(child) && child.type === DialogActions;
 
-/**
- * Reads the padding a caller passed through `sx`, so the pinned header and
- * actions line up with the scrollable content.
- */
+// the pinned rows take the content's own padding, whatever shape it is, so
+// the three line up at every breakpoint
 const readPadding = (sx: DialogProps['sx']) => {
   const styles = (sx ?? {}) as Record<string, unknown>;
 
-  const padding = styles.padding ?? styles.p;
-
-  if (typeof padding === 'number') return `${padding}px`;
-
-  return typeof padding === 'string' ? padding : DEFAULT_PADDING;
+  return (styles.padding ??
+    styles.p ??
+    DEFAULT_PADDING) as ResponsiveStyleValue<string | number>;
 };
 
 /**
- * Component for rendering a custom dialog.
- *
- * The title row (`header`) and the actions row stay in place, and only the
- * content between them scrolls, so the buttons stay reachable however short
- * the screen is. The content dissolves at an edge it scrolls past instead of
- * being cut off.
+ * The title row and the actions row stay in place, and only the content
+ * between them scrolls, so the buttons stay reachable however short the
+ * screen is. The content dissolves at an edge it scrolls past.
  *
  * A `DialogActions` child is pinned on its own, so a dialog only needs to pass
  * `actions` when its buttons sit inside a component of its own.
- *
- * @param {Object} props - Props for the CustomDialog component.
- * @param {boolean} props.open - Whether the dialog is open.
- * @param {VoidFunction} props.onClose - Function to handle dialog close event.
- * @param {React.ReactNode} props.header - Title row pinned above the content.
- * @param {React.ReactNode} props.actions - Actions row pinned below the content.
- * @param {React.ReactNode} props.children - Content to be rendered inside the dialog.
- * @param {SxProps} props.sx - Custom styling for the dialog content.
- * @returns {JSX.Element} CustomDialog component.
  */
 const Dialog = ({
   open,
@@ -68,21 +53,57 @@ const Dialog = ({
   PaperProps,
   header,
   actions,
+  title,
+  description,
+  closable,
 }: DialogProps) => {
+  const { t } = useAppTranslation();
+
   const ref = useScrollFade();
 
   const padding = readPadding(sx);
 
   const items = flatten(children);
 
-  // an actions row among the children is pinned as well, so a dialog keeps its
-  // buttons reachable without having to hand them over separately
+  // pinned as well, so a dialog need not hand its buttons over separately
   const childActions = items.filter(isActionsRow);
 
   const pinnedActions =
     actions ?? (childActions.length > 0 ? childActions : null);
 
   const content = actions ? items : items.filter((item) => !isActionsRow(item));
+
+  const titleRow = header ?? (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        // a title on its own sits on the close button's line
+        alignItems: description ? 'flex-start' : 'center',
+        gap: '8px',
+        width: '100%',
+      }}
+    >
+      <Stack spacing="2px">
+        <Typography className="h2">{title}</Typography>
+
+        {description && (
+          <Typography color="var(--grey-400)">{description}</Typography>
+        )}
+      </Stack>
+
+      {closable && (
+        <IconButton
+          aria-label={t('tr_close')}
+          onClick={onClose}
+          // pulled into its padding, so the icon lines up with the edge
+          sx={{ padding: '4px', margin: '-4px -4px -4px 0' }}
+        >
+          <IconClose color="var(--black)" />
+        </IconButton>
+      )}
+    </Box>
+  );
 
   /**
    * Handles the dialog close event.
@@ -125,9 +146,9 @@ const Dialog = ({
         },
       }}
     >
-      {header && (
+      {(header || title) && (
         <Box sx={{ flexShrink: 0, padding, paddingBottom: '8px' }}>
-          {header}
+          {titleRow}
         </Box>
       )}
 

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -1,16 +1,89 @@
-import { Dialog as MUIDialog, DialogContent } from '@mui/material';
+import {
+  Children,
+  Fragment,
+  isValidElement,
+  PropsWithChildren,
+  ReactNode,
+} from 'react';
+import { Box, Dialog as MUIDialog, DialogContent } from '@mui/material';
+import DialogActions from '@components/dialog_actions';
+import { useScrollFade } from '@hooks/index';
 import { DialogProps } from './index.types';
+
+const DEFAULT_PADDING = { mobile: '16px', desktop: '32px' };
+
+/**
+ * Flattens fragments, so an actions row a caller wrapped in one is still
+ * recognised as a child of the dialog.
+ */
+const flatten = (children: ReactNode): ReactNode[] =>
+  Children.toArray(children).flatMap((child) =>
+    isValidElement(child) && child.type === Fragment
+      ? flatten((child.props as PropsWithChildren).children)
+      : [child]
+  );
+
+const isActionsRow = (child: ReactNode) =>
+  isValidElement(child) && child.type === DialogActions;
+
+/**
+ * Reads the padding a caller passed through `sx`, so the pinned header and
+ * actions line up with the scrollable content.
+ */
+const readPadding = (sx: DialogProps['sx']) => {
+  const styles = (sx ?? {}) as Record<string, unknown>;
+
+  const padding = styles.padding ?? styles.p;
+
+  if (typeof padding === 'number') return `${padding}px`;
+
+  return typeof padding === 'string' ? padding : DEFAULT_PADDING;
+};
 
 /**
  * Component for rendering a custom dialog.
+ *
+ * The title row (`header`) and the actions row stay in place, and only the
+ * content between them scrolls, so the buttons stay reachable however short
+ * the screen is. The content dissolves at an edge it scrolls past instead of
+ * being cut off.
+ *
+ * A `DialogActions` child is pinned on its own, so a dialog only needs to pass
+ * `actions` when its buttons sit inside a component of its own.
+ *
  * @param {Object} props - Props for the CustomDialog component.
  * @param {boolean} props.open - Whether the dialog is open.
  * @param {VoidFunction} props.onClose - Function to handle dialog close event.
+ * @param {React.ReactNode} props.header - Title row pinned above the content.
+ * @param {React.ReactNode} props.actions - Actions row pinned below the content.
  * @param {React.ReactNode} props.children - Content to be rendered inside the dialog.
  * @param {SxProps} props.sx - Custom styling for the dialog content.
  * @returns {JSX.Element} CustomDialog component.
  */
-const Dialog = ({ open, onClose, children, sx, PaperProps }: DialogProps) => {
+const Dialog = ({
+  open,
+  onClose,
+  children,
+  sx,
+  PaperProps,
+  header,
+  actions,
+}: DialogProps) => {
+  const ref = useScrollFade();
+
+  const padding = readPadding(sx);
+
+  const items = flatten(children);
+
+  // an actions row among the children is pinned as well, so a dialog keeps its
+  // buttons reachable without having to hand them over separately
+  const childActions = items.filter(isActionsRow);
+
+  const pinnedActions =
+    actions ?? (childActions.length > 0 ? childActions : null);
+
+  const content = actions ? items : items.filter((item) => !isActionsRow(item));
+
   /**
    * Handles the dialog close event.
    * @param {string} reason - The reason for closing the dialog.
@@ -52,18 +125,35 @@ const Dialog = ({ open, onClose, children, sx, PaperProps }: DialogProps) => {
         },
       }}
     >
+      {header && (
+        <Box sx={{ flexShrink: 0, padding, paddingBottom: '8px' }}>
+          {header}
+        </Box>
+      )}
+
       <DialogContent
+        ref={ref}
+        className="scroll-fade-y"
         sx={{
-          padding: { mobile: '16px', desktop: '32px' },
+          padding,
           display: 'flex',
           flexDirection: 'column',
           gap: { mobile: '16px', desktop: '24px' },
           alignItems: 'flex-start',
+          flex: '1 1 auto',
+          minHeight: 0,
+          overscrollBehavior: 'contain',
           ...sx,
         }}
       >
-        {children}
+        {content}
       </DialogContent>
+
+      {pinnedActions && (
+        <Box sx={{ flexShrink: 0, padding, paddingTop: 0 }}>
+          {pinnedActions}
+        </Box>
+      )}
     </MUIDialog>
   );
 };

--- a/src/components/dialog/index.types.ts
+++ b/src/components/dialog/index.types.ts
@@ -7,14 +7,15 @@ export type DialogProps = PropsWithChildren & {
   sx?: SxProps<Theme>;
   PaperProps?: MUIDialogProps['PaperProps'];
 
-  /**
-   * Title row, pinned above the scrollable content.
-   */
+  title?: string;
+
+  description?: ReactNode;
+
+  closable?: boolean;
+
+  // takes the place of `title` and `description`
   header?: ReactNode;
 
-  /**
-   * Actions row, pinned below the scrollable content so the buttons stay
-   * reachable however long the content is.
-   */
+  // pinned below the content, for buttons that sit inside a component
   actions?: ReactNode;
 };

--- a/src/components/dialog/index.types.ts
+++ b/src/components/dialog/index.types.ts
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 import { DialogProps as MUIDialogProps, SxProps, Theme } from '@mui/material';
 
 export type DialogProps = PropsWithChildren & {
@@ -6,4 +6,15 @@ export type DialogProps = PropsWithChildren & {
   onClose: VoidFunction;
   sx?: SxProps<Theme>;
   PaperProps?: MUIDialogProps['PaperProps'];
+
+  /**
+   * Title row, pinned above the scrollable content.
+   */
+  header?: ReactNode;
+
+  /**
+   * Actions row, pinned below the scrollable content so the buttons stay
+   * reachable however long the content is.
+   */
+  actions?: ReactNode;
 };

--- a/src/components/scroll_area/index.tsx
+++ b/src/components/scroll_area/index.tsx
@@ -3,11 +3,8 @@ import { useScrollFade } from '@hooks/index';
 import { ScrollAreaProps } from './index.types';
 
 /**
- * A scrollable region whose content dissolves at the edges it scrolls past,
- * the same way a dialog's own content does.
- *
- * Use it for a list or panel that scrolls inside something else, where the
- * surrounding scroll area cannot tell that its content is cut off.
+ * A list or panel that scrolls inside something else, dissolving at the edges
+ * it scrolls past: the surrounding scroll area cannot tell that it is cut off.
  */
 const ScrollArea = ({ children, sx, ...props }: ScrollAreaProps) => {
   const ref = useScrollFade();

--- a/src/components/scroll_area/index.tsx
+++ b/src/components/scroll_area/index.tsx
@@ -1,0 +1,27 @@
+import { Box } from '@mui/material';
+import { useScrollFade } from '@hooks/index';
+import { ScrollAreaProps } from './index.types';
+
+/**
+ * A scrollable region whose content dissolves at the edges it scrolls past,
+ * the same way a dialog's own content does.
+ *
+ * Use it for a list or panel that scrolls inside something else, where the
+ * surrounding scroll area cannot tell that its content is cut off.
+ */
+const ScrollArea = ({ children, sx, ...props }: ScrollAreaProps) => {
+  const ref = useScrollFade();
+
+  return (
+    <Box
+      ref={ref}
+      className="scroll-fade-y"
+      sx={{ overflowY: 'auto', ...sx }}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default ScrollArea;

--- a/src/components/scroll_area/index.types.ts
+++ b/src/components/scroll_area/index.types.ts
@@ -1,0 +1,3 @@
+import { BoxProps } from '@mui/material';
+
+export type ScrollAreaProps = BoxProps;

--- a/src/features/about/index.tsx
+++ b/src/features/about/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Link } from '@mui/material';
-import { IconClose, IconInfo, IconLogo, IconRestart } from '@icons/index';
+import { IconLogo, IconRestart } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import { AboutProps } from './index.types';
 import useAbout from './useAbout';
@@ -24,32 +24,7 @@ const About = (props: AboutProps) => {
   const { t } = useAppTranslation();
 
   return (
-    <Dialog open={isOpen} onClose={handleClose}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'flex-start',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <IconInfo color="var(--black)" />
-        <Box
-          sx={{
-            display: 'flex',
-            padding: 'var(--radius-none)',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
-            flex: '1 0 0',
-          }}
-        >
-          <Typography className="h2">{t('tr_about')}</Typography>
-          <IconButton onClick={handleClose}>
-            <IconClose color="var(--black)" />
-          </IconButton>
-        </Box>
-      </Box>
-
+    <Dialog open={isOpen} onClose={handleClose} title={t('tr_about')} closable>
       <Box
         sx={{
           display: 'flex',

--- a/src/features/congregation/app_access/join_requests/accept/index.tsx
+++ b/src/features/congregation/app_access/join_requests/accept/index.tsx
@@ -9,6 +9,7 @@ import Autocomplete from '@components/autocomplete';
 import Button from '@components/button';
 import Checkbox from '@components/checkbox';
 import Dialog from '@components/dialog';
+import ScrollArea from '@components/scroll_area';
 import DialogActions from '@components/dialog_actions';
 import SwitchWithLabel from '@components/switch_with_label';
 import Typography from '@components/typography';
@@ -56,9 +57,14 @@ const AcceptRequest = (props: AcceptRequestProps) => {
           {t('tr_joinRequestsAcceptDesc')}
         </Typography>
 
-        <Stack
-          spacing="24px"
-          sx={{ maxHeight: '300px', overflow: 'auto', padding: '8px 0' }}
+        <ScrollArea
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '24px',
+            maxHeight: '300px',
+            padding: '8px 0',
+          }}
         >
           <Autocomplete
             label={t('tr_bindWithRecord')}
@@ -158,7 +164,7 @@ const AcceptRequest = (props: AcceptRequestProps) => {
               />
             </SwitchContainer>
           </Stack>
-        </Stack>
+        </ScrollArea>
 
         <DialogActions>
           <Button variant="secondary" onClick={handleClose}>

--- a/src/features/congregation/app_access/user_details/delete_user/index.tsx
+++ b/src/features/congregation/app_access/user_details/delete_user/index.tsx
@@ -17,7 +17,7 @@ const DeleteUser = ({ open, onClose, user }: DeleteUserType) => {
   return (
     <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h3">{t('tr_deleteUserProfile')}</Typography>
+        <Typography className="h2">{t('tr_deleteUserProfile')}</Typography>
 
         <Markup
           className="body-regular"

--- a/src/features/congregation/app_access/user_details/invitation_code/delete_code/index.tsx
+++ b/src/features/congregation/app_access/user_details/invitation_code/delete_code/index.tsx
@@ -16,7 +16,7 @@ const DeleteCode = ({ open, onClose, user }: DeleteCodeType) => {
   return (
     <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h3">{t('tr_deleteInvitationCode')}</Typography>
+        <Typography className="h2">{t('tr_deleteInvitationCode')}</Typography>
 
         <Typography color="var(--grey-400)">
           {t('tr_deleteInvitationCodeDesc')}

--- a/src/features/congregation/field_service_groups/group_members/index.tsx
+++ b/src/features/congregation/field_service_groups/group_members/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Stack } from '@mui/material';
+import ScrollArea from '@components/scroll_area';
 import { ReactSortable } from 'react-sortablejs';
 import { useAppTranslation } from '@hooks/index';
 import { GroupMembersProps, UsersOption } from './index.types';
@@ -22,7 +23,7 @@ const GroupMembers = (props: GroupMembersProps) => {
 
   return (
     <Stack spacing="8px" width="100%">
-      <Box sx={{ maxHeight: '300px', overflow: 'auto' }}>
+      <ScrollArea sx={{ maxHeight: '300px' }}>
         {members.length > 0 && (
           <ReactSortable
             list={members}
@@ -38,7 +39,7 @@ const GroupMembers = (props: GroupMembersProps) => {
             ))}
           </ReactSortable>
         )}
-      </Box>
+      </ScrollArea>
 
       <Autocomplete
         variant="standard"

--- a/src/features/congregation/field_service_groups/groups_reorder/index.tsx
+++ b/src/features/congregation/field_service_groups/groups_reorder/index.tsx
@@ -16,9 +16,24 @@ const GroupsReorder = (props: GroupsReorderProps) => {
     useGroupsReorder(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
-      <Typography className="h2">{t('tr_reorderGroupsTitle')}</Typography>
-
+    <Dialog
+      onClose={props.onClose}
+      open={props.open}
+      sx={{ padding: '24px' }}
+      header={
+        <Typography className="h2">{t('tr_reorderGroupsTitle')}</Typography>
+      }
+      actions={
+        <DialogActions>
+          <Button variant="secondary" onClick={props.onClose}>
+            {t('tr_cancel')}
+          </Button>
+          <Button variant="main" onClick={handleSaveChanges}>
+            {t('tr_save')}
+          </Button>
+        </DialogActions>
+      }
+    >
       <GroupsContainer>
         <ReactSortable
           list={groups}
@@ -30,15 +45,6 @@ const GroupsReorder = (props: GroupsReorderProps) => {
           ))}
         </ReactSortable>
       </GroupsContainer>
-
-      <DialogActions>
-        <Button variant="secondary" onClick={props.onClose}>
-          {t('tr_cancel')}
-        </Button>
-        <Button variant="main" onClick={handleSaveChanges}>
-          {t('tr_save')}
-        </Button>
-      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/congregation/settings/congregation_privacy/access_code_change/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/access_code_change/index.tsx
@@ -27,7 +27,7 @@ const AccessCodeChange = ({ open, onClose }: AccessCodeChangeType) => {
   return (
     <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h3">{t('tr_changeAccessCode')}</Typography>
+        <Typography className="h2">{t('tr_changeAccessCode')}</Typography>
 
         <Typography color="var(--grey-400)">
           {t('tr_changeAccessCodeDesc')}

--- a/src/features/congregation/settings/congregation_privacy/delete_congregation/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/delete_congregation/index.tsx
@@ -31,7 +31,7 @@ const DeleteCongregation = () => {
           sx={{ padding: '24px' }}
         >
           <Stack spacing="16px">
-            <Typography className="h3">{t('tr_deleteCongregation')}</Typography>
+            <Typography className="h2">{t('tr_deleteCongregation')}</Typography>
 
             <Typography color="var(--grey-400)">
               {t('tr_deleteCongregationDesc')}

--- a/src/features/congregation/settings/congregation_privacy/master_key_change/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/master_key_change/index.tsx
@@ -27,7 +27,7 @@ const MasterKeyChange = ({ open, onClose }: MasterKeyChangeType) => {
   return (
     <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h3">{t('tr_masterKeyChange')}</Typography>
+        <Typography className="h2">{t('tr_masterKeyChange')}</Typography>
 
         <Typography color="var(--grey-400)">
           {t('tr_masterKeyChangeDesc')}

--- a/src/features/contact/index.tsx
+++ b/src/features/contact/index.tsx
@@ -1,5 +1,3 @@
-import { Box, IconButton } from '@mui/material';
-import { IconClose, IconMail } from '@icons/index';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
 import useContact from './useContact';
@@ -7,7 +5,6 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
 import TextMarkup from '@components/text_markup';
-import Typography from '@components/typography';
 import TextField from '@components/textfield';
 
 const Contact = () => {
@@ -25,36 +22,12 @@ const Contact = () => {
   } = useContact();
 
   return (
-    <Dialog open={isOpen} onClose={handleClose}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'flex-start',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <IconMail color="var(--black)" />
-        <Box
-          sx={{
-            display: 'flex',
-            padding: 'var(--radius-none)',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
-            flex: '1 0 0',
-          }}
-        >
-          <Typography className="h2">{t('tr_shareFeeback')}</Typography>
-          <IconButton
-            disableRipple
-            sx={{ padding: 0, margin: 0 }}
-            onClick={handleClose}
-          >
-            <IconClose color="var(--black)" />
-          </IconButton>
-        </Box>
-      </Box>
-
+    <Dialog
+      open={isOpen}
+      onClose={handleClose}
+      title={t('tr_shareFeeback')}
+      closable
+    >
       <TextMarkup
         content={t('tr_shareFeebackDesc')}
         className="body-regular"

--- a/src/features/meetings/assignments_history_dialog/index.tsx
+++ b/src/features/meetings/assignments_history_dialog/index.tsx
@@ -26,7 +26,7 @@ const AssignmentsHistoryDialog = ({
         }}
       >
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-          <Typography className="h3">{t('tr_assignmentsHistory')}</Typography>
+          <Typography className="h2">{t('tr_assignmentsHistory')}</Typography>
           <Typography color="var(--grey-400)">{person}</Typography>
         </Box>
 

--- a/src/features/meetings/schedule_publish/index.tsx
+++ b/src/features/meetings/schedule_publish/index.tsx
@@ -27,7 +27,7 @@ const SchedulePublish = (props: SchedulePublishProps) => {
       sx={{ padding: '24px' }}
       header={
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-          <Typography className="h3">{t('tr_publishSchedules')}</Typography>
+          <Typography className="h2">{t('tr_publishSchedules')}</Typography>
           <Typography color="var(--grey-400)">
             {t('tr_publishSchedulesDesc')}
           </Typography>

--- a/src/features/meetings/schedule_publish/index.tsx
+++ b/src/features/meetings/schedule_publish/index.tsx
@@ -21,14 +21,34 @@ const SchedulePublish = (props: SchedulePublishProps) => {
   } = useSchedulePublish(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h3">{t('tr_publishSchedules')}</Typography>
-        <Typography color="var(--grey-400)">
-          {t('tr_publishSchedulesDesc')}
-        </Typography>
-      </Box>
-
+    <Dialog
+      onClose={props.onClose}
+      open={props.open}
+      sx={{ padding: '24px' }}
+      header={
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <Typography className="h3">{t('tr_publishSchedules')}</Typography>
+          <Typography color="var(--grey-400)">
+            {t('tr_publishSchedulesDesc')}
+          </Typography>
+        </Box>
+      }
+      actions={
+        <DialogActions>
+          <Button variant="secondary" onClick={props.onClose}>
+            {t('tr_cancel')}
+          </Button>
+          <Button
+            variant="main"
+            disabled={isProcessing}
+            onClick={handlePublishSchedule}
+            endIcon={isProcessing && <IconLoading />}
+          >
+            {t('tr_publish')}
+          </Button>
+        </DialogActions>
+      }
+    >
       <Stack
         direction="row"
         spacing="24px"
@@ -45,20 +65,6 @@ const SchedulePublish = (props: SchedulePublishProps) => {
           />
         ))}
       </Stack>
-
-      <DialogActions>
-        <Button variant="secondary" onClick={props.onClose}>
-          {t('tr_cancel')}
-        </Button>
-        <Button
-          variant="main"
-          disabled={isProcessing}
-          onClick={handlePublishSchedule}
-          endIcon={isProcessing && <IconLoading />}
-        >
-          {t('tr_publish')}
-        </Button>
-      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/meetings/weekend_editor/song_selector/index.tsx
+++ b/src/features/meetings/weekend_editor/song_selector/index.tsx
@@ -36,7 +36,7 @@ const SongSelector = (props: SongSelectorProps) => {
             width: '100%',
           }}
         >
-          <Typography className="h3">{t('tr_selectSong')}</Typography>
+          <Typography className="h2">{t('tr_selectSong')}</Typography>
 
           <IconButton sx={{ padding: 0 }} onClick={handleClose}>
             <IconClose color="var(--grey-400)" />

--- a/src/features/meetings/weekend_editor/speakers_catalog/index.tsx
+++ b/src/features/meetings/weekend_editor/speakers_catalog/index.tsx
@@ -36,7 +36,7 @@ const SpeakersCatalog = (props: SpeakersCatalogType) => {
       >
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-            <Typography className="h3">{t('tr_speakersCatalog')}</Typography>
+            <Typography className="h2">{t('tr_speakersCatalog')}</Typography>
             <Typography className="h4" color="var(--grey-400)">
               {t('tr_speakersWithCount', { speakersCount: count })}
             </Typography>

--- a/src/features/quick_settings/index.tsx
+++ b/src/features/quick_settings/index.tsx
@@ -17,7 +17,7 @@ const QuickSettings = ({
   return (
     <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-        <Typography className="h3">
+        <Typography className="h2">
           {t('tr_quickSettings')} – {title}
         </Typography>
         <Typography color="var(--grey-400)">

--- a/src/features/support/index.tsx
+++ b/src/features/support/index.tsx
@@ -1,9 +1,9 @@
-import { Box, Divider, IconButton } from '@mui/material';
+import { Box, Divider } from '@mui/material';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import TextMarkup from '@components/text_markup';
 import Typography from '@components/typography';
-import { IconClose, IconDonate, IconDutiesDistribution } from '@icons/index';
+import { IconDonate, IconDutiesDistribution } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import useSupport from './useSupport';
 
@@ -13,7 +13,12 @@ const Support = () => {
   const { handleClose, isOpen, handleOpenDonate, handleOpenDoc } = useSupport();
 
   return (
-    <Dialog open={isOpen} onClose={handleClose}>
+    <Dialog
+      open={isOpen}
+      onClose={handleClose}
+      title={t('tr_supportApp')}
+      closable
+    >
       <Box
         sx={{
           display: 'flex',
@@ -22,27 +27,6 @@ const Support = () => {
           width: '100%',
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: '8px' }}>
-          <IconDonate color="var(--black)" />
-          <Box
-            sx={{
-              display: 'flex',
-              padding: 'var(--radius-none)',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-              flex: '1 0 0',
-            }}
-          >
-            <Typography className="h2">{t('tr_supportApp')}</Typography>
-            <IconButton
-              disableRipple
-              sx={{ padding: 0, margin: 0 }}
-              onClick={handleClose}
-            >
-              <IconClose color="var(--black)" />
-            </IconButton>
-          </Box>
-        </Box>
         <TextMarkup content={t('tr_supportAppDesc')} className="body-regular" />
       </Box>
 

--- a/src/features/whats_new/index.tsx
+++ b/src/features/whats_new/index.tsx
@@ -31,17 +31,24 @@ const WhatsNew = () => {
       open={open}
       onClose={handleClose}
       sx={{ padding: '24px', position: 'relative' }}
-    >
-      <Stack spacing="8px" width="100%">
+      header={
         <Box
           sx={{
             display: 'flex',
             flexDirection: 'row',
             justifyContent: 'space-between',
-            alignItems: 'center',
+            alignItems: 'flex-start',
+            gap: '8px',
+            width: '100%',
           }}
         >
-          <Typography className="h2">{t('tr_newOrganizedUpdate')}</Typography>
+          <Stack spacing="2px">
+            <Typography className="h2">{t('tr_newOrganizedUpdate')}</Typography>
+
+            <Typography color="var(--grey-400)">
+              {t('tr_newOrganizedUpdateDesc')}
+            </Typography>
+          </Stack>
 
           {!isLoading && images.length > 0 && (
             <IconButton onClick={handleClose}>
@@ -49,12 +56,19 @@ const WhatsNew = () => {
             </IconButton>
           )}
         </Box>
-
-        <Typography color="var(--grey-400)">
-          {t('tr_newOrganizedUpdateDesc')}
-        </Typography>
-      </Stack>
-
+      }
+      actions={
+        !isLoading && (
+          <ButtonsAction
+            slides={images}
+            current={currentImage}
+            onClose={handleClose}
+            onNext={handleNextAction}
+            onBack={handleBackAction}
+          />
+        )
+      }
+    >
       {isLoading && <WaitingLoader size={72} variant="standard" />}
 
       {!isLoading && (
@@ -74,14 +88,6 @@ const WhatsNew = () => {
               showHeader={images.length > 0}
             />
           )}
-
-          <ButtonsAction
-            slides={images}
-            current={currentImage}
-            onClose={handleClose}
-            onNext={handleNextAction}
-            onBack={handleBackAction}
-          />
         </>
       )}
     </Dialog>

--- a/src/features/whats_new/index.tsx
+++ b/src/features/whats_new/index.tsx
@@ -1,13 +1,9 @@
-import { Box, Stack } from '@mui/material';
-import { IconClose } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import useWhatsNew from './useWhatsNew';
 import ButtonsAction from './buttons_action';
 import Dialog from '@components/dialog';
-import IconButton from '@components/icon_button';
 import ImageViewer from './image_viewer';
 import ImprovementsList from './improvements_list';
-import Typography from '@components/typography';
 import WaitingLoader from '@components/waiting_loader';
 
 const WhatsNew = () => {
@@ -31,32 +27,9 @@ const WhatsNew = () => {
       open={open}
       onClose={handleClose}
       sx={{ padding: '24px', position: 'relative' }}
-      header={
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'row',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
-            gap: '8px',
-            width: '100%',
-          }}
-        >
-          <Stack spacing="2px">
-            <Typography className="h2">{t('tr_newOrganizedUpdate')}</Typography>
-
-            <Typography color="var(--grey-400)">
-              {t('tr_newOrganizedUpdateDesc')}
-            </Typography>
-          </Stack>
-
-          {!isLoading && images.length > 0 && (
-            <IconButton onClick={handleClose}>
-              <IconClose color="var(--black)" />
-            </IconButton>
-          )}
-        </Box>
-      }
+      title={t('tr_newOrganizedUpdate')}
+      description={t('tr_newOrganizedUpdateDesc')}
+      closable={!isLoading && images.length > 0}
       actions={
         !isLoading && (
           <ButtonsAction

--- a/src/global/index.css
+++ b/src/global/index.css
@@ -177,3 +177,212 @@ span .text-markup:last-child {
 body iframe {
   opacity: 0;
 }
+
+/* Fades a scrollable element at the edges that hide content. The stops follow
+   a curve that flattens at both ends, so neither the edge itself nor the point
+   where the fade meets the content reads as a line. The scrollbar keeps a strip
+   of its own and is never faded. `--scroll-fade-top` and `--scroll-fade-bottom`
+   are how much of each fade shows, from 0 to 1, `--scroll-fade-size` how far it
+   reaches, and `--scroll-fade-gutter` the width of the scrollbar. */
+.scroll-fade-y {
+  /* 48px, but never more than a quarter of a short scroll area: a phone in
+     landscape can leave a dialog barely 110px of content, and two full fades
+     would swallow most of it */
+  --scroll-fade-size: min(48px, 25%);
+  --scroll-fade-gutter: 0px;
+
+  -webkit-mask-image:
+    linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 1)) 0px,
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9988))
+        calc(var(--scroll-fade-size) * 0.05),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9914))
+        calc(var(--scroll-fade-size) * 0.1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9734))
+        calc(var(--scroll-fade-size) * 0.15),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9421))
+        calc(var(--scroll-fade-size) * 0.2),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.8965))
+        calc(var(--scroll-fade-size) * 0.25),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.8369))
+        calc(var(--scroll-fade-size) * 0.3),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.7648))
+        calc(var(--scroll-fade-size) * 0.35),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.6826))
+        calc(var(--scroll-fade-size) * 0.4),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.5931))
+        calc(var(--scroll-fade-size) * 0.45),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.5))
+        calc(var(--scroll-fade-size) * 0.5),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.4069))
+        calc(var(--scroll-fade-size) * 0.55),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.3174))
+        calc(var(--scroll-fade-size) * 0.6),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.2352))
+        calc(var(--scroll-fade-size) * 0.65),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.1631))
+        calc(var(--scroll-fade-size) * 0.7),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.1035))
+        calc(var(--scroll-fade-size) * 0.75),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0579))
+        calc(var(--scroll-fade-size) * 0.8),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0266))
+        calc(var(--scroll-fade-size) * 0.85),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0086))
+        calc(var(--scroll-fade-size) * 0.9),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0012))
+        calc(var(--scroll-fade-size) * 0.95),
+      #000 calc(var(--scroll-fade-size) * 1),
+      #000 calc(100% - var(--scroll-fade-size) * 1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0012))
+        calc(100% - var(--scroll-fade-size) * 0.95),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0086))
+        calc(100% - var(--scroll-fade-size) * 0.9),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0266))
+        calc(100% - var(--scroll-fade-size) * 0.85),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0579))
+        calc(100% - var(--scroll-fade-size) * 0.8),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.1035))
+        calc(100% - var(--scroll-fade-size) * 0.75),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.1631))
+        calc(100% - var(--scroll-fade-size) * 0.7),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.2352))
+        calc(100% - var(--scroll-fade-size) * 0.65),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.3174))
+        calc(100% - var(--scroll-fade-size) * 0.6),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.4069))
+        calc(100% - var(--scroll-fade-size) * 0.55),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.5))
+        calc(100% - var(--scroll-fade-size) * 0.5),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.5931))
+        calc(100% - var(--scroll-fade-size) * 0.45),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.6826))
+        calc(100% - var(--scroll-fade-size) * 0.4),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.7648))
+        calc(100% - var(--scroll-fade-size) * 0.35),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.8369))
+        calc(100% - var(--scroll-fade-size) * 0.3),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.8965))
+        calc(100% - var(--scroll-fade-size) * 0.25),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9421))
+        calc(100% - var(--scroll-fade-size) * 0.2),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9734))
+        calc(100% - var(--scroll-fade-size) * 0.15),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9914))
+        calc(100% - var(--scroll-fade-size) * 0.1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9988))
+        calc(100% - var(--scroll-fade-size) * 0.05),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 1)) 100%
+    ),
+    linear-gradient(#000, #000);
+  -webkit-mask-size:
+    calc(100% - var(--scroll-fade-gutter)) 100%,
+    var(--scroll-fade-gutter) 100%;
+  -webkit-mask-position:
+    left top,
+    right top;
+  -webkit-mask-repeat: no-repeat;
+  mask-image:
+    linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 1)) 0px,
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9988))
+        calc(var(--scroll-fade-size) * 0.05),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9914))
+        calc(var(--scroll-fade-size) * 0.1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9734))
+        calc(var(--scroll-fade-size) * 0.15),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9421))
+        calc(var(--scroll-fade-size) * 0.2),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.8965))
+        calc(var(--scroll-fade-size) * 0.25),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.8369))
+        calc(var(--scroll-fade-size) * 0.3),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.7648))
+        calc(var(--scroll-fade-size) * 0.35),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.6826))
+        calc(var(--scroll-fade-size) * 0.4),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.5931))
+        calc(var(--scroll-fade-size) * 0.45),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.5))
+        calc(var(--scroll-fade-size) * 0.5),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.4069))
+        calc(var(--scroll-fade-size) * 0.55),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.3174))
+        calc(var(--scroll-fade-size) * 0.6),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.2352))
+        calc(var(--scroll-fade-size) * 0.65),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.1631))
+        calc(var(--scroll-fade-size) * 0.7),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.1035))
+        calc(var(--scroll-fade-size) * 0.75),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0579))
+        calc(var(--scroll-fade-size) * 0.8),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0266))
+        calc(var(--scroll-fade-size) * 0.85),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0086))
+        calc(var(--scroll-fade-size) * 0.9),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0012))
+        calc(var(--scroll-fade-size) * 0.95),
+      #000 calc(var(--scroll-fade-size) * 1),
+      #000 calc(100% - var(--scroll-fade-size) * 1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0012))
+        calc(100% - var(--scroll-fade-size) * 0.95),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0086))
+        calc(100% - var(--scroll-fade-size) * 0.9),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0266))
+        calc(100% - var(--scroll-fade-size) * 0.85),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0579))
+        calc(100% - var(--scroll-fade-size) * 0.8),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.1035))
+        calc(100% - var(--scroll-fade-size) * 0.75),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.1631))
+        calc(100% - var(--scroll-fade-size) * 0.7),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.2352))
+        calc(100% - var(--scroll-fade-size) * 0.65),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.3174))
+        calc(100% - var(--scroll-fade-size) * 0.6),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.4069))
+        calc(100% - var(--scroll-fade-size) * 0.55),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.5))
+        calc(100% - var(--scroll-fade-size) * 0.5),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.5931))
+        calc(100% - var(--scroll-fade-size) * 0.45),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.6826))
+        calc(100% - var(--scroll-fade-size) * 0.4),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.7648))
+        calc(100% - var(--scroll-fade-size) * 0.35),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.8369))
+        calc(100% - var(--scroll-fade-size) * 0.3),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.8965))
+        calc(100% - var(--scroll-fade-size) * 0.25),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9421))
+        calc(100% - var(--scroll-fade-size) * 0.2),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9734))
+        calc(100% - var(--scroll-fade-size) * 0.15),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9914))
+        calc(100% - var(--scroll-fade-size) * 0.1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9988))
+        calc(100% - var(--scroll-fade-size) * 0.05),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 1)) 100%
+    ),
+    linear-gradient(#000, #000);
+  mask-size:
+    calc(100% - var(--scroll-fade-gutter)) 100%,
+    var(--scroll-fade-gutter) 100%;
+  mask-position:
+    left top,
+    right top;
+  mask-repeat: no-repeat;
+}
+
+/* the scrollbar sits on the other side when the interface is right to left */
+[dir='rtl'] .scroll-fade-y {
+  -webkit-mask-position:
+    right top,
+    left top;
+  mask-position:
+    right top,
+    left top;
+}

--- a/src/global/index.css
+++ b/src/global/index.css
@@ -179,15 +179,11 @@ body iframe {
 }
 
 /* Fades a scrollable element at the edges that hide content. The stops follow
-   a curve that flattens at both ends, so neither the edge itself nor the point
-   where the fade meets the content reads as a line. The scrollbar keeps a strip
-   of its own and is never faded. `--scroll-fade-top` and `--scroll-fade-bottom`
-   are how much of each fade shows, from 0 to 1, `--scroll-fade-size` how far it
-   reaches, and `--scroll-fade-gutter` the width of the scrollbar. */
+   a curve that flattens at both ends: a straight ramp reads as a line rather
+   than a fade. The scrollbar keeps a strip of its own and is never faded. */
 .scroll-fade-y {
-  /* 48px, but never more than a quarter of a short scroll area: a phone in
-     landscape can leave a dialog barely 110px of content, and two full fades
-     would swallow most of it */
+  /* capped: a phone in landscape can leave a dialog 110px of content, and two
+     full fades would swallow most of it */
   --scroll-fade-size: min(48px, 25%);
   --scroll-fade-gutter: 0px;
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { default as useAppTranslation } from './useAppTranslation';
 export { default as useBreakpoints } from './useBreakpoints';
+export { default as useScrollFade } from './useScrollFade';
 export { default as useIsTouchDevice } from './useIsTouchDevice';
 export { default as useFirebaseAuth } from './useFirebaseAuth';
 export { default as useGlobal } from './useGlobal';

--- a/src/hooks/useScrollFade.tsx
+++ b/src/hooks/useScrollFade.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+// the scroll distance over which an edge reveals its fade
+const REVEAL = 8;
+
+/**
+ * Reveals the `scroll-fade-y` fades of a scrollable element, by how far its
+ * content has scrolled past each edge: none at rest, full once content is
+ * hidden.
+ *
+ * The amounts are written straight to the CSS variables the fades read, so
+ * scrolling neither re-renders nor waits on a transition.
+ *
+ * The element is attached through a callback ref: content mounted late, such
+ * as a dialog opening or an image arriving, is picked up on its own.
+ */
+const useScrollFade = () => {
+  const cleanup = useRef<VoidFunction>(null);
+
+  const ref = useCallback((el: HTMLDivElement | null) => {
+    cleanup.current?.();
+    cleanup.current = null;
+
+    if (!el) return;
+
+    let frame = 0;
+
+    const update = () => {
+      const hiddenAbove = el.scrollTop;
+      const hiddenBelow = el.scrollHeight - el.clientHeight - el.scrollTop;
+
+      const reveal = (hidden: number) =>
+        Math.min(Math.max(hidden, 0) / REVEAL, 1).toFixed(3);
+
+      el.style.setProperty('--scroll-fade-top', reveal(hiddenAbove));
+      el.style.setProperty('--scroll-fade-bottom', reveal(hiddenBelow));
+    };
+
+    // scrolling asks for at most one update per frame
+    const onScroll = () => {
+      if (frame) return;
+
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        update();
+      });
+    };
+
+    // the scrollbar keeps its own strip of the mask, so it is not faded. Its
+    // width only changes with the element, not while scrolling
+    const measureGutter = () => {
+      el.style.setProperty(
+        '--scroll-fade-gutter',
+        `${el.offsetWidth - el.clientWidth}px`
+      );
+    };
+
+    const observer = new ResizeObserver(() => {
+      measureGutter();
+      update();
+    });
+    observer.observe(el);
+
+    const observeChildren = () => {
+      for (const child of el.children) observer.observe(child);
+    };
+
+    // images, translations and query results land after the first render
+    const children = new MutationObserver(() => {
+      observeChildren();
+      update();
+    });
+
+    observeChildren();
+    children.observe(el, { childList: true });
+    el.addEventListener('scroll', onScroll, { passive: true });
+    measureGutter();
+    update();
+
+    cleanup.current = () => {
+      cancelAnimationFrame(frame);
+      el.removeEventListener('scroll', onScroll);
+      observer.disconnect();
+      children.disconnect();
+    };
+  }, []);
+
+  useEffect(() => () => cleanup.current?.(), []);
+
+  return ref;
+};
+
+export default useScrollFade;

--- a/src/hooks/useScrollFade.tsx
+++ b/src/hooks/useScrollFade.tsx
@@ -4,15 +4,11 @@ import { useCallback, useEffect, useRef } from 'react';
 const REVEAL = 8;
 
 /**
- * Reveals the `scroll-fade-y` fades of a scrollable element, by how far its
- * content has scrolled past each edge: none at rest, full once content is
- * hidden.
+ * Reveals the `scroll-fade-y` fades of an element by how far its content has
+ * scrolled past each edge, writing the amounts straight to the CSS variables
+ * the fades read: no re-render, no transition to wait on.
  *
- * The amounts are written straight to the CSS variables the fades read, so
- * scrolling neither re-renders nor waits on a transition.
- *
- * The element is attached through a callback ref: content mounted late, such
- * as a dialog opening or an image arriving, is picked up on its own.
+ * Attached by callback ref, so content that mounts late is picked up.
  */
 const useScrollFade = () => {
   const cleanup = useRef<VoidFunction>(null);
@@ -46,8 +42,7 @@ const useScrollFade = () => {
       });
     };
 
-    // the scrollbar keeps its own strip of the mask, so it is not faded. Its
-    // width only changes with the element, not while scrolling
+    // the scrollbar keeps its own strip of the mask, so it is not faded
     const measureGutter = () => {
       el.style.setProperty(
         '--scroll-fade-gutter',
@@ -59,9 +54,12 @@ const useScrollFade = () => {
       measureGutter();
       update();
     });
-    observer.observe(el);
 
     const observeChildren = () => {
+      // re-observing from scratch drops children that have gone
+      observer.disconnect();
+      observer.observe(el);
+
       for (const child of el.children) observer.observe(child);
     };
 


### PR DESCRIPTION
# Description

A dialog put its title, content and buttons in one scrolling box. On a short screen — a phone in landscape, or simply a long dialog — the buttons scrolled out of reach and the content was cut off at a hard edge. Titles were also built by hand in every dialog: some `h2`, some `h3`, three with an icon beside them, and a different padding in a handful of them.

This change gives the shared `Dialog` a fixed title row and a fixed actions row, with only the content between them scrolling, and one way of writing that title row.

**Layout.** The paper is now three parts: the title row, the scrolling content, and the actions row. A `DialogActions` child is recognised and pinned on its own, so 40 dialogs keep their buttons reachable without being touched. A dialog whose buttons live inside a component of its own passes them through `actions`.

**Title row.** `title`, `description` and `closable` build the row, always `h2`, pinned above the content. A title on its own sits on the close button's line; a title with a description starts beside it. Dialogs whose header is not a plain title still pass their own row through `header`.

**Fading edges.** The content dissolves at an edge it scrolls past, revealed by how far it has scrolled rather than switched on: nothing at rest, full once content is hidden. The stops follow a curve that flattens at both ends, so neither the edge nor the point where the fade meets the content reads as a line, and the scrollbar keeps a strip of its own so it is never faded. The fade is capped at a quarter of a short scroll area — a phone in landscape can leave a dialog barely 110px of content, and two full fades would swallow it.

`scroll-fade-y` and `useScrollFade` are not dialog-specific: `ScrollArea` uses them for lists that scroll inside a dialog, and any scroll region can.

**Also in here:** `h3` titles are gone (10 dialogs), the default padding is 24px — what 44 of the 59 dialogs were already asking for — and the leading icons are dropped from About, Support and Share feedback.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Not covered yet

48 dialogs still build their title inside the content, and 19 use a custom button row rather than `DialogActions`. They behave exactly as they do on `main` — they simply do not gain the pinned rows yet. Migrating them is the same edit repeated, and is better reviewed separately from the component change.

Three dialogs keep a padding of their own: `report_form_dialog` (`0`, deliberate — its paper is transparent and its content carries its own surfaces), `bible_studies/editor` (`12px 24px`) and `speaker_details` (`16px`). The last two look accidental and are best folded in when their headers are migrated.

## Testing

Checked by hand in test mode, on desktop and at 375px, 400px and a 747x320 landscape phone: What's new with a long improvements list, reorder groups, publish schedules, About, Support, Share feedback, log out, export settings, delete person, the attendance clicker and the person edit form. Verified the actions row sits outside the scroll area, the fade appears only where content is hidden, the scrollbar stays crisp, and right-to-left mirrors correctly. `npm run build` and `eslint src` pass with no new warnings.

The repository has no unit tests and its Cypress spec only loads the page, so none of this is covered automatically.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sws2apps/organized-app/pull/5422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->