### PR TITLE
tweak(ui): standardize the dialog header and spacing

### DIFF
--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -5,17 +5,18 @@ import {
   PropsWithChildren,
   ReactNode,
 } from 'react';
-import { Box, Dialog as MUIDialog, DialogContent } from '@mui/material';
+import { Box, Dialog as MUIDialog, DialogContent, Stack } from '@mui/material';
+import { ResponsiveStyleValue } from '@mui/system';
 import DialogActions from '@components/dialog_actions';
-import { useScrollFade } from '@hooks/index';
+import IconButton from '@components/icon_button';
+import Typography from '@components/typography';
+import { IconClose } from '@components/icons';
+import { useAppTranslation, useScrollFade } from '@hooks/index';
 import { DialogProps } from './index.types';
 
-const DEFAULT_PADDING = { mobile: '16px', desktop: '32px' };
+const DEFAULT_PADDING = '24px';
 
-/**
- * Flattens fragments, so an actions row a caller wrapped in one is still
- * recognised as a child of the dialog.
- */
+// fragments are flattened, so an actions row wrapped in one is still found
 const flatten = (children: ReactNode): ReactNode[] =>
   Children.toArray(children).flatMap((child) =>
     isValidElement(child) && child.type === Fragment
@@ -26,39 +27,23 @@ const flatten = (children: ReactNode): ReactNode[] =>
 const isActionsRow = (child: ReactNode) =>
   isValidElement(child) && child.type === DialogActions;
 
-/**
- * Reads the padding a caller passed through `sx`, so the pinned header and
- * actions line up with the scrollable content.
- */
+// the pinned rows take the content's own padding, whatever shape it is, so
+// the three line up at every breakpoint
 const readPadding = (sx: DialogProps['sx']) => {
   const styles = (sx ?? {}) as Record<string, unknown>;
 
-  const padding = styles.padding ?? styles.p;
-
-  if (typeof padding === 'number') return `${padding}px`;
-
-  return typeof padding === 'string' ? padding : DEFAULT_PADDING;
+  return (styles.padding ??
+    styles.p ??
+    DEFAULT_PADDING) as ResponsiveStyleValue<string | number>;
 };
 
 /**
- * Component for rendering a custom dialog.
- *
- * The title row (`header`) and the actions row stay in place, and only the
- * content between them scrolls, so the buttons stay reachable however short
- * the screen is. The content dissolves at an edge it scrolls past instead of
- * being cut off.
+ * The title row and the actions row stay in place, and only the content
+ * between them scrolls, so the buttons stay reachable however short the
+ * screen is. The content dissolves at an edge it scrolls past.
  *
  * A `DialogActions` child is pinned on its own, so a dialog only needs to pass
  * `actions` when its buttons sit inside a component of its own.
- *
- * @param {Object} props - Props for the CustomDialog component.
- * @param {boolean} props.open - Whether the dialog is open.
- * @param {VoidFunction} props.onClose - Function to handle dialog close event.
- * @param {React.ReactNode} props.header - Title row pinned above the content.
- * @param {React.ReactNode} props.actions - Actions row pinned below the content.
- * @param {React.ReactNode} props.children - Content to be rendered inside the dialog.
- * @param {SxProps} props.sx - Custom styling for the dialog content.
- * @returns {JSX.Element} CustomDialog component.
  */
 const Dialog = ({
   open,
@@ -68,21 +53,57 @@ const Dialog = ({
   PaperProps,
   header,
   actions,
+  title,
+  description,
+  closable,
 }: DialogProps) => {
+  const { t } = useAppTranslation();
+
   const ref = useScrollFade();
 
   const padding = readPadding(sx);
 
   const items = flatten(children);
 
-  // an actions row among the children is pinned as well, so a dialog keeps its
-  // buttons reachable without having to hand them over separately
+  // pinned as well, so a dialog need not hand its buttons over separately
   const childActions = items.filter(isActionsRow);
 
   const pinnedActions =
     actions ?? (childActions.length > 0 ? childActions : null);
 
   const content = actions ? items : items.filter((item) => !isActionsRow(item));
+
+  const titleRow = header ?? (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        // a title on its own sits on the close button's line
+        alignItems: description ? 'flex-start' : 'center',
+        gap: '8px',
+        width: '100%',
+      }}
+    >
+      <Stack spacing="2px">
+        <Typography className="h2">{title}</Typography>
+
+        {description && (
+          <Typography color="var(--grey-400)">{description}</Typography>
+        )}
+      </Stack>
+
+      {closable && (
+        <IconButton
+          aria-label={t('tr_close')}
+          onClick={onClose}
+          // pulled into its padding, so the icon lines up with the edge
+          sx={{ padding: '4px', margin: '-4px -4px -4px 0' }}
+        >
+          <IconClose color="var(--black)" />
+        </IconButton>
+      )}
+    </Box>
+  );
 
   /**
    * Handles the dialog close event.
@@ -125,9 +146,9 @@ const Dialog = ({
         },
       }}
     >
-      {header && (
+      {(header || title) && (
         <Box sx={{ flexShrink: 0, padding, paddingBottom: '8px' }}>
-          {header}
+          {titleRow}
         </Box>
       )}
 

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -4,8 +4,16 @@ import {
   isValidElement,
   PropsWithChildren,
   ReactNode,
+  useId,
 } from 'react';
-import { Box, Dialog as MUIDialog, DialogContent, Stack } from '@mui/material';
+import {
+  Box,
+  Dialog as MUIDialog,
+  DialogContent,
+  Stack,
+  Theme,
+  useTheme,
+} from '@mui/material';
 import { ResponsiveStyleValue } from '@mui/system';
 import DialogActions from '@components/dialog_actions';
 import IconButton from '@components/icon_button';
@@ -14,7 +22,7 @@ import { IconClose } from '@components/icons';
 import { useAppTranslation, useScrollFade } from '@hooks/index';
 import { DialogProps } from './index.types';
 
-const DEFAULT_PADDING = '24px';
+const DEFAULT_PADDING = 'var(--dialog-padding)';
 
 // fragments are flattened, so an actions row wrapped in one is still found
 const flatten = (children: ReactNode): ReactNode[] =>
@@ -27,10 +35,32 @@ const flatten = (children: ReactNode): ReactNode[] =>
 const isActionsRow = (child: ReactNode) =>
   isValidElement(child) && child.type === DialogActions;
 
+// sx is an object, a callback taking the theme, or an array of either
+const resolveSx = (
+  sx: DialogProps['sx'],
+  theme: Theme
+): Record<string, unknown> => {
+  if (!sx) return {};
+
+  if (Array.isArray(sx)) {
+    return sx.reduce<Record<string, unknown>>(
+      (merged, entry) => ({
+        ...merged,
+        ...resolveSx(entry as DialogProps['sx'], theme),
+      }),
+      {}
+    );
+  }
+
+  if (typeof sx === 'function') return resolveSx(sx(theme), theme);
+
+  return sx as Record<string, unknown>;
+};
+
 // the pinned rows take the content's own padding, whatever shape it is, so
 // the three line up at every breakpoint
-const readPadding = (sx: DialogProps['sx']) => {
-  const styles = (sx ?? {}) as Record<string, unknown>;
+const readPadding = (sx: DialogProps['sx'], theme: Theme) => {
+  const styles = resolveSx(sx, theme);
 
   return (styles.padding ??
     styles.p ??
@@ -59,9 +89,14 @@ const Dialog = ({
 }: DialogProps) => {
   const { t } = useAppTranslation();
 
+  // dialogs can be open at once, so each names itself by its own heading
+  const titleId = useId();
+
   const ref = useScrollFade();
 
-  const padding = readPadding(sx);
+  const theme = useTheme();
+
+  const padding = readPadding(sx, theme);
 
   const items = flatten(children);
 
@@ -71,9 +106,12 @@ const Dialog = ({
   const pinnedActions =
     actions ?? (childActions.length > 0 ? childActions : null);
 
-  const content = actions ? items : items.filter((item) => !isActionsRow(item));
+  const content = (
+    actions ? items : items.filter((item) => !isActionsRow(item))
+  ).filter((item) => item !== null && item !== false && item !== '');
 
-  const titleRow = header ?? (
+  // the close button belongs to the row whichever way the header is built
+  const titleRow = (header || title || closable) && (
     <Box
       sx={{
         display: 'flex',
@@ -84,13 +122,17 @@ const Dialog = ({
         width: '100%',
       }}
     >
-      <Stack spacing="2px">
-        <Typography className="h2">{title}</Typography>
+      {header ?? (
+        <Stack spacing="2px">
+          <Typography className="h2" id={titleId}>
+            {title}
+          </Typography>
 
-        {description && (
-          <Typography color="var(--grey-400)">{description}</Typography>
-        )}
-      </Stack>
+          {description && (
+            <Typography color="var(--grey-400)">{description}</Typography>
+          )}
+        </Stack>
+      )}
 
       {closable && (
         <IconButton
@@ -122,6 +164,7 @@ const Dialog = ({
       fullWidth
       open={open}
       onClose={handleClose}
+      aria-labelledby={title ? titleId : undefined}
       sx={{
         boxSizing: 'border-box',
         '.MuiPaper-root': {
@@ -146,32 +189,59 @@ const Dialog = ({
         },
       }}
     >
-      {(header || title) && (
-        <Box sx={{ flexShrink: 0, padding, paddingBottom: '8px' }}>
+      {titleRow && (
+        <Box
+          sx={{
+            flexShrink: 0,
+            padding,
+            paddingBottom: 'var(--dialog-header-gap)',
+          }}
+        >
           {titleRow}
         </Box>
       )}
 
-      <DialogContent
-        ref={ref}
-        className="scroll-fade-y"
-        sx={{
-          padding,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: { mobile: '16px', desktop: '24px' },
-          alignItems: 'flex-start',
-          flex: '1 1 auto',
-          minHeight: 0,
-          overscrollBehavior: 'contain',
-          ...sx,
-        }}
-      >
-        {content}
-      </DialogContent>
+      {content.length > 0 && (
+        <DialogContent
+          ref={ref}
+          className="scroll-fade-y"
+          sx={{
+            padding,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: {
+              mobile: 'var(--dialog-gap-mobile)',
+              desktop: 'var(--dialog-gap)',
+            },
+            alignItems: 'flex-start',
+            flex: '1 1 auto',
+            minHeight: 0,
+            overscrollBehavior: 'contain',
+            ...sx,
+          }}
+        >
+          {content}
+        </DialogContent>
+      )}
 
       {pinnedActions && (
-        <Box sx={{ flexShrink: 0, padding, paddingTop: 0 }}>
+        <Box
+          sx={{
+            flexShrink: 0,
+            padding,
+            // with nothing between the rows, the buttons take the gap the
+            // content would have held
+            paddingTop:
+              content.length > 0
+                ? 0
+                : {
+                    mobile:
+                      'calc(var(--dialog-gap-mobile) - var(--dialog-header-gap))',
+                    desktop:
+                      'calc(var(--dialog-gap) - var(--dialog-header-gap))',
+                  },
+          }}
+        >
           {pinnedActions}
         </Box>
       )}

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -1,16 +1,89 @@
-import { Dialog as MUIDialog, DialogContent } from '@mui/material';
+import {
+  Children,
+  Fragment,
+  isValidElement,
+  PropsWithChildren,
+  ReactNode,
+} from 'react';
+import { Box, Dialog as MUIDialog, DialogContent } from '@mui/material';
+import DialogActions from '@components/dialog_actions';
+import { useScrollFade } from '@hooks/index';
 import { DialogProps } from './index.types';
+
+const DEFAULT_PADDING = { mobile: '16px', desktop: '32px' };
+
+/**
+ * Flattens fragments, so an actions row a caller wrapped in one is still
+ * recognised as a child of the dialog.
+ */
+const flatten = (children: ReactNode): ReactNode[] =>
+  Children.toArray(children).flatMap((child) =>
+    isValidElement(child) && child.type === Fragment
+      ? flatten((child.props as PropsWithChildren).children)
+      : [child]
+  );
+
+const isActionsRow = (child: ReactNode) =>
+  isValidElement(child) && child.type === DialogActions;
+
+/**
+ * Reads the padding a caller passed through `sx`, so the pinned header and
+ * actions line up with the scrollable content.
+ */
+const readPadding = (sx: DialogProps['sx']) => {
+  const styles = (sx ?? {}) as Record<string, unknown>;
+
+  const padding = styles.padding ?? styles.p;
+
+  if (typeof padding === 'number') return `${padding}px`;
+
+  return typeof padding === 'string' ? padding : DEFAULT_PADDING;
+};
 
 /**
  * Component for rendering a custom dialog.
+ *
+ * The title row (`header`) and the actions row stay in place, and only the
+ * content between them scrolls, so the buttons stay reachable however short
+ * the screen is. The content dissolves at an edge it scrolls past instead of
+ * being cut off.
+ *
+ * A `DialogActions` child is pinned on its own, so a dialog only needs to pass
+ * `actions` when its buttons sit inside a component of its own.
+ *
  * @param {Object} props - Props for the CustomDialog component.
  * @param {boolean} props.open - Whether the dialog is open.
  * @param {VoidFunction} props.onClose - Function to handle dialog close event.
+ * @param {React.ReactNode} props.header - Title row pinned above the content.
+ * @param {React.ReactNode} props.actions - Actions row pinned below the content.
  * @param {React.ReactNode} props.children - Content to be rendered inside the dialog.
  * @param {SxProps} props.sx - Custom styling for the dialog content.
  * @returns {JSX.Element} CustomDialog component.
  */
-const Dialog = ({ open, onClose, children, sx, PaperProps }: DialogProps) => {
+const Dialog = ({
+  open,
+  onClose,
+  children,
+  sx,
+  PaperProps,
+  header,
+  actions,
+}: DialogProps) => {
+  const ref = useScrollFade();
+
+  const padding = readPadding(sx);
+
+  const items = flatten(children);
+
+  // an actions row among the children is pinned as well, so a dialog keeps its
+  // buttons reachable without having to hand them over separately
+  const childActions = items.filter(isActionsRow);
+
+  const pinnedActions =
+    actions ?? (childActions.length > 0 ? childActions : null);
+
+  const content = actions ? items : items.filter((item) => !isActionsRow(item));
+
   /**
    * Handles the dialog close event.
    * @param {string} reason - The reason for closing the dialog.
@@ -52,18 +125,35 @@ const Dialog = ({ open, onClose, children, sx, PaperProps }: DialogProps) => {
         },
       }}
     >
+      {header && (
+        <Box sx={{ flexShrink: 0, padding, paddingBottom: '8px' }}>
+          {header}
+        </Box>
+      )}
+
       <DialogContent
+        ref={ref}
+        className="scroll-fade-y"
         sx={{
-          padding: { mobile: '16px', desktop: '32px' },
+          padding,
           display: 'flex',
           flexDirection: 'column',
           gap: { mobile: '16px', desktop: '24px' },
           alignItems: 'flex-start',
+          flex: '1 1 auto',
+          minHeight: 0,
+          overscrollBehavior: 'contain',
           ...sx,
         }}
       >
-        {children}
+        {content}
       </DialogContent>
+
+      {pinnedActions && (
+        <Box sx={{ flexShrink: 0, padding, paddingTop: 0 }}>
+          {pinnedActions}
+        </Box>
+      )}
     </MUIDialog>
   );
 };

--- a/src/components/dialog/index.types.ts
+++ b/src/components/dialog/index.types.ts
@@ -7,14 +7,15 @@ export type DialogProps = PropsWithChildren & {
   sx?: SxProps<Theme>;
   PaperProps?: MUIDialogProps['PaperProps'];
 
-  /**
-   * Title row, pinned above the scrollable content.
-   */
+  title?: string;
+
+  description?: ReactNode;
+
+  closable?: boolean;
+
+  // takes the place of `title` and `description`
   header?: ReactNode;
 
-  /**
-   * Actions row, pinned below the scrollable content so the buttons stay
-   * reachable however long the content is.
-   */
+  // pinned below the content, for buttons that sit inside a component
   actions?: ReactNode;
 };

--- a/src/components/dialog/index.types.ts
+++ b/src/components/dialog/index.types.ts
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 import { DialogProps as MUIDialogProps, SxProps, Theme } from '@mui/material';
 
 export type DialogProps = PropsWithChildren & {
@@ -6,4 +6,15 @@ export type DialogProps = PropsWithChildren & {
   onClose: VoidFunction;
   sx?: SxProps<Theme>;
   PaperProps?: MUIDialogProps['PaperProps'];
+
+  /**
+   * Title row, pinned above the scrollable content.
+   */
+  header?: ReactNode;
+
+  /**
+   * Actions row, pinned below the scrollable content so the buttons stay
+   * reachable however long the content is.
+   */
+  actions?: ReactNode;
 };

--- a/src/components/scroll_area/index.tsx
+++ b/src/components/scroll_area/index.tsx
@@ -6,15 +6,26 @@ import { ScrollAreaProps } from './index.types';
  * A list or panel that scrolls inside something else, dissolving at the edges
  * it scrolls past: the surrounding scroll area cannot tell that it is cut off.
  */
-const ScrollArea = ({ children, sx, ...props }: ScrollAreaProps) => {
-  const ref = useScrollFade();
+const ScrollArea = ({
+  children,
+  sx,
+  className,
+  ref,
+  ...props
+}: ScrollAreaProps) => {
+  const fadeRef = useScrollFade();
 
   return (
     <Box
-      ref={ref}
-      className="scroll-fade-y"
-      sx={{ overflowY: 'auto', ...sx }}
       {...props}
+      ref={(el: HTMLDivElement | null) => {
+        fadeRef(el);
+
+        if (typeof ref === 'function') ref(el);
+        else if (ref) ref.current = el;
+      }}
+      className={['scroll-fade-y', className].filter(Boolean).join(' ')}
+      sx={{ overflowY: 'auto', ...sx }}
     >
       {children}
     </Box>

--- a/src/components/scroll_area/index.tsx
+++ b/src/components/scroll_area/index.tsx
@@ -3,11 +3,8 @@ import { useScrollFade } from '@hooks/index';
 import { ScrollAreaProps } from './index.types';
 
 /**
- * A scrollable region whose content dissolves at the edges it scrolls past,
- * the same way a dialog's own content does.
- *
- * Use it for a list or panel that scrolls inside something else, where the
- * surrounding scroll area cannot tell that its content is cut off.
+ * A list or panel that scrolls inside something else, dissolving at the edges
+ * it scrolls past: the surrounding scroll area cannot tell that it is cut off.
  */
 const ScrollArea = ({ children, sx, ...props }: ScrollAreaProps) => {
   const ref = useScrollFade();

--- a/src/components/scroll_area/index.tsx
+++ b/src/components/scroll_area/index.tsx
@@ -1,0 +1,27 @@
+import { Box } from '@mui/material';
+import { useScrollFade } from '@hooks/index';
+import { ScrollAreaProps } from './index.types';
+
+/**
+ * A scrollable region whose content dissolves at the edges it scrolls past,
+ * the same way a dialog's own content does.
+ *
+ * Use it for a list or panel that scrolls inside something else, where the
+ * surrounding scroll area cannot tell that its content is cut off.
+ */
+const ScrollArea = ({ children, sx, ...props }: ScrollAreaProps) => {
+  const ref = useScrollFade();
+
+  return (
+    <Box
+      ref={ref}
+      className="scroll-fade-y"
+      sx={{ overflowY: 'auto', ...sx }}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default ScrollArea;

--- a/src/components/scroll_area/index.types.ts
+++ b/src/components/scroll_area/index.types.ts
@@ -1,0 +1,3 @@
+import { BoxProps } from '@mui/material';
+
+export type ScrollAreaProps = BoxProps;

--- a/src/features/about/index.tsx
+++ b/src/features/about/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Link } from '@mui/material';
-import { IconClose, IconInfo, IconLogo, IconRestart } from '@icons/index';
+import { IconLogo, IconRestart } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import { AboutProps } from './index.types';
 import useAbout from './useAbout';
@@ -24,32 +24,7 @@ const About = (props: AboutProps) => {
   const { t } = useAppTranslation();
 
   return (
-    <Dialog open={isOpen} onClose={handleClose}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'flex-start',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <IconInfo color="var(--black)" />
-        <Box
-          sx={{
-            display: 'flex',
-            padding: 'var(--radius-none)',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
-            flex: '1 0 0',
-          }}
-        >
-          <Typography className="h2">{t('tr_about')}</Typography>
-          <IconButton onClick={handleClose}>
-            <IconClose color="var(--black)" />
-          </IconButton>
-        </Box>
-      </Box>
-
+    <Dialog open={isOpen} onClose={handleClose} title={t('tr_about')} closable>
       <Box
         sx={{
           display: 'flex',

--- a/src/features/activities/upcoming_events/delete_event/index.tsx
+++ b/src/features/activities/upcoming_events/delete_event/index.tsx
@@ -3,30 +3,27 @@ import { useAppTranslation } from '@hooks/index';
 import { DeleteEventProps } from './index.types';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
-import Typography from '@components/typography';
 
 const DeleteEvent = ({ open, title, onClose, onConfirm }: DeleteEventProps) => {
   const { t } = useAppTranslation();
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Stack spacing="16px">
-        <Typography className="h2">{t('tr_deleteEventTitle')}</Typography>
-
-        <Typography color="var(--grey-400)">
-          {t('tr_deleteEventDesc', { eventName: title })}
-        </Typography>
-      </Stack>
-
-      <Stack spacing="8px" width="100%">
-        <Button variant="main" color="red" onClick={onConfirm}>
-          {t('tr_delete')}
-        </Button>
-        <Button variant="secondary" onClick={onClose}>
-          {t('tr_cancel')}
-        </Button>
-      </Stack>
-    </Dialog>
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_deleteEventTitle')}
+      description={t('tr_deleteEventDesc', { eventName: title })}
+      actions={
+        <Stack spacing="8px" width="100%">
+          <Button variant="main" color="red" onClick={onConfirm}>
+            {t('tr_delete')}
+          </Button>
+          <Button variant="secondary" onClick={onClose}>
+            {t('tr_cancel')}
+          </Button>
+        </Stack>
+      }
+    />
   );
 };
 

--- a/src/features/app_install/install_dialog/index.tsx
+++ b/src/features/app_install/install_dialog/index.tsx
@@ -4,7 +4,6 @@ import { PwaInstallGuide } from '@utils/pwa';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import TextMarkup from '@components/text_markup';
-import Typography from '@components/typography';
 
 type InstallDialogProps = {
   open: boolean;
@@ -27,9 +26,16 @@ const InstallDialog = ({ open, onClose, guide }: InstallDialogProps) => {
   const { t } = useAppTranslation();
 
   return (
-    <Dialog open={open} onClose={onClose}>
-      <Typography className="h2">{t('tr_installApp')}</Typography>
-
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={t('tr_installApp')}
+      actions={
+        <Button variant="main" onClick={onClose} sx={{ width: '100%' }}>
+          {t('tr_ok')}
+        </Button>
+      }
+    >
       <Stack spacing="4px" width="100%">
         <TextMarkup
           content={t(GUIDE_TEXT[guide])}
@@ -37,10 +43,6 @@ const InstallDialog = ({ open, onClose, guide }: InstallDialogProps) => {
           color="var(--grey-400)"
         />
       </Stack>
-
-      <Button variant="main" onClick={onClose} sx={{ width: '100%' }}>
-        {t('tr_ok')}
-      </Button>
     </Dialog>
   );
 };

--- a/src/features/congregation/app_access/join_requests/accept/index.tsx
+++ b/src/features/congregation/app_access/join_requests/accept/index.tsx
@@ -49,10 +49,11 @@ const AcceptRequest = (props: AcceptRequestProps) => {
         {t('tr_accept')}
       </Button>
 
-      <Dialog onClose={handleClose} open={open} sx={{ padding: '24px' }}>
-        <Typography className="h2">
-          {t('tr_joinRequestsAccept', { user: fullname })}
-        </Typography>
+      <Dialog
+        onClose={handleClose}
+        open={open}
+        title={t('tr_joinRequestsAccept', { user: fullname })}
+      >
         <Typography className="body-regular" color="var(--grey-400)">
           {t('tr_joinRequestsAcceptDesc')}
         </Typography>

--- a/src/features/congregation/app_access/join_requests/accept/index.tsx
+++ b/src/features/congregation/app_access/join_requests/accept/index.tsx
@@ -9,6 +9,7 @@ import Autocomplete from '@components/autocomplete';
 import Button from '@components/button';
 import Checkbox from '@components/checkbox';
 import Dialog from '@components/dialog';
+import ScrollArea from '@components/scroll_area';
 import DialogActions from '@components/dialog_actions';
 import SwitchWithLabel from '@components/switch_with_label';
 import Typography from '@components/typography';
@@ -56,9 +57,14 @@ const AcceptRequest = (props: AcceptRequestProps) => {
           {t('tr_joinRequestsAcceptDesc')}
         </Typography>
 
-        <Stack
-          spacing="24px"
-          sx={{ maxHeight: '300px', overflow: 'auto', padding: '8px 0' }}
+        <ScrollArea
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '24px',
+            maxHeight: '300px',
+            padding: '8px 0',
+          }}
         >
           <Autocomplete
             label={t('tr_bindWithRecord')}
@@ -158,7 +164,7 @@ const AcceptRequest = (props: AcceptRequestProps) => {
               />
             </SwitchContainer>
           </Stack>
-        </Stack>
+        </ScrollArea>
 
         <DialogActions>
           <Button variant="secondary" onClick={handleClose}>

--- a/src/features/congregation/app_access/user_add/index.tsx
+++ b/src/features/congregation/app_access/user_add/index.tsx
@@ -8,7 +8,7 @@ const UserAdd = ({ open, onClose }: UserAddType) => {
   const { currentStep, user, handleMoveStep, handleSetUser } = useUserAdd();
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
+    <Dialog onClose={onClose} open={open}>
       {currentStep === 'select' && (
         <PersonSelect
           onClose={onClose}

--- a/src/features/congregation/app_access/user_details/delete_user/index.tsx
+++ b/src/features/congregation/app_access/user_details/delete_user/index.tsx
@@ -17,7 +17,7 @@ const DeleteUser = ({ open, onClose, user }: DeleteUserType) => {
   return (
     <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h3">{t('tr_deleteUserProfile')}</Typography>
+        <Typography className="h2">{t('tr_deleteUserProfile')}</Typography>
 
         <Markup
           className="body-regular"

--- a/src/features/congregation/app_access/user_details/delete_user/index.tsx
+++ b/src/features/congregation/app_access/user_details/delete_user/index.tsx
@@ -15,7 +15,7 @@ const DeleteUser = ({ open, onClose, user }: DeleteUserType) => {
   const { isProcessing, handleDeleteUser } = useDeleteUser(user, onClose);
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
+    <Dialog onClose={onClose} open={open}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <Typography className="h2">{t('tr_deleteUserProfile')}</Typography>
 

--- a/src/features/congregation/app_access/user_details/invitation_code/delete_code/index.tsx
+++ b/src/features/congregation/app_access/user_details/invitation_code/delete_code/index.tsx
@@ -16,7 +16,7 @@ const DeleteCode = ({ open, onClose, user }: DeleteCodeType) => {
   return (
     <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h3">{t('tr_deleteInvitationCode')}</Typography>
+        <Typography className="h2">{t('tr_deleteInvitationCode')}</Typography>
 
         <Typography color="var(--grey-400)">
           {t('tr_deleteInvitationCodeDesc')}

--- a/src/features/congregation/app_access/user_details/invitation_code/delete_code/index.tsx
+++ b/src/features/congregation/app_access/user_details/invitation_code/delete_code/index.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
 import { DeleteCodeType } from './index.types';
@@ -6,7 +5,6 @@ import useDeleteCode from './useDeleteCode';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 
 const DeleteCode = ({ open, onClose, user }: DeleteCodeType) => {
   const { t } = useAppTranslation();
@@ -14,15 +12,12 @@ const DeleteCode = ({ open, onClose, user }: DeleteCodeType) => {
   const { isProcessing, handleDeleteCode } = useDeleteCode(user, onClose);
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h2">{t('tr_deleteInvitationCode')}</Typography>
-
-        <Typography color="var(--grey-400)">
-          {t('tr_deleteInvitationCodeDesc')}
-        </Typography>
-      </Box>
-
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_deleteInvitationCode')}
+      description={t('tr_deleteInvitationCodeDesc')}
+    >
       <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}

--- a/src/features/congregation/field_service_groups/export_groups/ExportGroupsDialog.tsx
+++ b/src/features/congregation/field_service_groups/export_groups/ExportGroupsDialog.tsx
@@ -24,10 +24,27 @@ const ExportGroupsDialog = ({
   const handleExport = () => onExport({ orientation, fontSize });
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_exportSettings')}
+      actions={
+        <Stack spacing="8px" width="100%">
+          <Button
+            variant="main"
+            onClick={handleExport}
+            disabled={isProcessing}
+            endIcon={isProcessing ? <IconLoading /> : undefined}
+          >
+            {t('tr_export')}
+          </Button>
+          <Button variant="secondary" disabled={isProcessing} onClick={onClose}>
+            {t('tr_cancel')}
+          </Button>
+        </Stack>
+      }
+    >
       <Stack spacing="24px" width="100%">
-        <Typography className="h2">{t('tr_exportSettings')}</Typography>
-
         <Stack spacing="8px">
           <Typography className="body-small-semibold" color="var(--grey-400)">
             {t('tr_orientation')}
@@ -77,20 +94,6 @@ const ExportGroupsDialog = ({
               control={<Radio />}
             />
           </RadioGroup>
-        </Stack>
-
-        <Stack spacing="8px" width="100%">
-          <Button
-            variant="main"
-            onClick={handleExport}
-            disabled={isProcessing}
-            endIcon={isProcessing ? <IconLoading /> : undefined}
-          >
-            {t('tr_export')}
-          </Button>
-          <Button variant="secondary" disabled={isProcessing} onClick={onClose}>
-            {t('tr_cancel')}
-          </Button>
         </Stack>
       </Stack>
     </Dialog>

--- a/src/features/congregation/field_service_groups/group_item/edit_delete_dialog/index.tsx
+++ b/src/features/congregation/field_service_groups/group_item/edit_delete_dialog/index.tsx
@@ -12,7 +12,7 @@ const EditDeleteDialog = ({
   type,
 }: EditDeleteDialogProps) => {
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
+    <Dialog onClose={onClose} open={open}>
       {type === 'edit' && (
         <GroupEdit
           group={group}

--- a/src/features/congregation/field_service_groups/group_item/remove_person/index.tsx
+++ b/src/features/congregation/field_service_groups/group_item/remove_person/index.tsx
@@ -14,7 +14,7 @@ const RemovePerson = (props: RemovePersonProps) => {
   const { group_name, person_name } = useRemovePerson(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
+    <Dialog onClose={props.onClose} open={props.open}>
       <Stack spacing="16px">
         <Typography className="h2">
           {t('tr_removePublisher', { PersonName: person_name })}

--- a/src/features/congregation/field_service_groups/group_members/index.tsx
+++ b/src/features/congregation/field_service_groups/group_members/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Stack } from '@mui/material';
+import ScrollArea from '@components/scroll_area';
 import { ReactSortable } from 'react-sortablejs';
 import { useAppTranslation } from '@hooks/index';
 import { GroupMembersProps, UsersOption } from './index.types';
@@ -22,7 +23,7 @@ const GroupMembers = (props: GroupMembersProps) => {
 
   return (
     <Stack spacing="8px" width="100%">
-      <Box sx={{ maxHeight: '300px', overflow: 'auto' }}>
+      <ScrollArea sx={{ maxHeight: '300px' }}>
         {members.length > 0 && (
           <ReactSortable
             list={members}
@@ -38,7 +39,7 @@ const GroupMembers = (props: GroupMembersProps) => {
             ))}
           </ReactSortable>
         )}
-      </Box>
+      </ScrollArea>
 
       <Autocomplete
         variant="standard"

--- a/src/features/congregation/field_service_groups/groups_reorder/index.tsx
+++ b/src/features/congregation/field_service_groups/groups_reorder/index.tsx
@@ -19,7 +19,6 @@ const GroupsReorder = (props: GroupsReorderProps) => {
     <Dialog
       onClose={props.onClose}
       open={props.open}
-      sx={{ padding: '24px' }}
       header={
         <Typography className="h2">{t('tr_reorderGroupsTitle')}</Typography>
       }

--- a/src/features/congregation/field_service_groups/groups_reorder/index.tsx
+++ b/src/features/congregation/field_service_groups/groups_reorder/index.tsx
@@ -16,9 +16,24 @@ const GroupsReorder = (props: GroupsReorderProps) => {
     useGroupsReorder(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
-      <Typography className="h2">{t('tr_reorderGroupsTitle')}</Typography>
-
+    <Dialog
+      onClose={props.onClose}
+      open={props.open}
+      sx={{ padding: '24px' }}
+      header={
+        <Typography className="h2">{t('tr_reorderGroupsTitle')}</Typography>
+      }
+      actions={
+        <DialogActions>
+          <Button variant="secondary" onClick={props.onClose}>
+            {t('tr_cancel')}
+          </Button>
+          <Button variant="main" onClick={handleSaveChanges}>
+            {t('tr_save')}
+          </Button>
+        </DialogActions>
+      }
+    >
       <GroupsContainer>
         <ReactSortable
           list={groups}
@@ -30,15 +45,6 @@ const GroupsReorder = (props: GroupsReorderProps) => {
           ))}
         </ReactSortable>
       </GroupsContainer>
-
-      <DialogActions>
-        <Button variant="secondary" onClick={props.onClose}>
-          {t('tr_cancel')}
-        </Button>
-        <Button variant="main" onClick={handleSaveChanges}>
-          {t('tr_save')}
-        </Button>
-      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/congregation/settings/congregation_privacy/access_code_change/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/access_code_change/index.tsx
@@ -27,7 +27,7 @@ const AccessCodeChange = ({ open, onClose }: AccessCodeChangeType) => {
   return (
     <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h3">{t('tr_changeAccessCode')}</Typography>
+        <Typography className="h2">{t('tr_changeAccessCode')}</Typography>
 
         <Typography color="var(--grey-400)">
           {t('tr_changeAccessCodeDesc')}

--- a/src/features/congregation/settings/congregation_privacy/access_code_change/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/access_code_change/index.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import { IconEncryptionKey } from '@components/icons';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
@@ -8,7 +7,6 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
 import TextField from '@components/textfield';
-import Typography from '@components/typography';
 
 const AccessCodeChange = ({ open, onClose }: AccessCodeChangeType) => {
   const { t } = useAppTranslation();
@@ -25,15 +23,12 @@ const AccessCodeChange = ({ open, onClose }: AccessCodeChangeType) => {
   } = useAccessCodeChange(onClose);
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h2">{t('tr_changeAccessCode')}</Typography>
-
-        <Typography color="var(--grey-400)">
-          {t('tr_changeAccessCodeDesc')}
-        </Typography>
-      </Box>
-
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_changeAccessCode')}
+      description={t('tr_changeAccessCodeDesc')}
+    >
       <TextField
         type="password"
         label={currentAccessCode.length > 0 ? t('tr_accessCodeCurrent') : ''}

--- a/src/features/congregation/settings/congregation_privacy/delete_congregation/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/delete_congregation/index.tsx
@@ -31,7 +31,7 @@ const DeleteCongregation = () => {
           sx={{ padding: '24px' }}
         >
           <Stack spacing="16px">
-            <Typography className="h3">{t('tr_deleteCongregation')}</Typography>
+            <Typography className="h2">{t('tr_deleteCongregation')}</Typography>
 
             <Typography color="var(--grey-400)">
               {t('tr_deleteCongregationDesc')}

--- a/src/features/congregation/settings/congregation_privacy/delete_congregation/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/delete_congregation/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from '@mui/material';
+import { Box } from '@mui/material';
 import { IconDelete, IconEncryptionKey } from '@components/icons';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
@@ -7,7 +7,6 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
 import TextField from '@components/textfield';
-import Typography from '@components/typography';
 
 const DeleteCongregation = () => {
   const { t } = useAppTranslation();
@@ -28,16 +27,9 @@ const DeleteCongregation = () => {
         <Dialog
           onClose={handleDeleteClose}
           open={modalOpen}
-          sx={{ padding: '24px' }}
+          title={t('tr_deleteCongregation')}
+          description={t('tr_deleteCongregationDesc')}
         >
-          <Stack spacing="16px">
-            <Typography className="h2">{t('tr_deleteCongregation')}</Typography>
-
-            <Typography color="var(--grey-400)">
-              {t('tr_deleteCongregationDesc')}
-            </Typography>
-          </Stack>
-
           <TextField
             type="password"
             placeholder={t('tr_deleteCongregationMasterKeyRequired')}

--- a/src/features/congregation/settings/congregation_privacy/master_key_change/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/master_key_change/index.tsx
@@ -27,7 +27,7 @@ const MasterKeyChange = ({ open, onClose }: MasterKeyChangeType) => {
   return (
     <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h3">{t('tr_masterKeyChange')}</Typography>
+        <Typography className="h2">{t('tr_masterKeyChange')}</Typography>
 
         <Typography color="var(--grey-400)">
           {t('tr_masterKeyChangeDesc')}

--- a/src/features/congregation/settings/congregation_privacy/master_key_change/index.tsx
+++ b/src/features/congregation/settings/congregation_privacy/master_key_change/index.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import { IconEncryptionKey } from '@components/icons';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
@@ -8,7 +7,6 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
 import TextField from '@components/textfield';
-import Typography from '@components/typography';
 
 const MasterKeyChange = ({ open, onClose }: MasterKeyChangeType) => {
   const { t } = useAppTranslation();
@@ -25,15 +23,12 @@ const MasterKeyChange = ({ open, onClose }: MasterKeyChangeType) => {
   } = useMasterKeyChange(onClose);
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h2">{t('tr_masterKeyChange')}</Typography>
-
-        <Typography color="var(--grey-400)">
-          {t('tr_masterKeyChangeDesc')}
-        </Typography>
-      </Box>
-
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_masterKeyChange')}
+      description={t('tr_masterKeyChangeDesc')}
+    >
       <TextField
         type="password"
         label={currentMasterKey.length > 0 ? t('tr_masterKeyCurrent') : ''}

--- a/src/features/congregation/settings/import_export/index.tsx
+++ b/src/features/congregation/settings/import_export/index.tsx
@@ -14,7 +14,7 @@ const ImportExport = (props: ImportExportType) => {
     useImportExport(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
+    <Dialog onClose={props.onClose} open={props.open}>
       {state === 'import/export' && (
         <Stack spacing="16px">
           <Typography className="h2">{t('tr_importExportTitle')}</Typography>

--- a/src/features/congregation/settings/language_groups/group_add/index.tsx
+++ b/src/features/congregation/settings/language_groups/group_add/index.tsx
@@ -4,7 +4,6 @@ import useGroupAdd from './useGroupAdd';
 import Dialog from '@components/dialog';
 import GroupDetails from './group_details';
 import GroupMembers from './group_members';
-import Typography from '@components/typography';
 
 const GroupAdd = (props: GroupAddProps) => {
   const { t } = useAppTranslation();
@@ -22,9 +21,12 @@ const GroupAdd = (props: GroupAddProps) => {
   } = useGroupAdd(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ gap: '16px' }}>
-      <Typography className="h2">{t('tr_addNewLangGroup')}</Typography>
-
+    <Dialog
+      onClose={props.onClose}
+      open={props.open}
+      sx={{ gap: '16px' }}
+      title={t('tr_addNewLangGroup')}
+    >
       {step === 'start' && (
         <GroupDetails
           onClose={props.onClose}

--- a/src/features/congregation/settings/language_groups/group_delete/index.tsx
+++ b/src/features/congregation/settings/language_groups/group_delete/index.tsx
@@ -26,11 +26,9 @@ const GroupDelete = (props: GroupDeleteProps) => {
       <Dialog
         onClose={handleClose}
         open={open}
-        sx={{ padding: '24px', gap: '16px' }}
+        sx={{ gap: '16px' }}
+        title={t('tr_languageGroupDelete', { languageGroup: group_name })}
       >
-        <Typography className="h2">
-          {t('tr_languageGroupDelete', { languageGroup: group_name })}
-        </Typography>
         <Typography className="body-regular" color="var(--grey-400)">
           {t('tr_languageGroupDeleteDesc')}
         </Typography>

--- a/src/features/congregation/settings/language_groups/group_info/index.tsx
+++ b/src/features/congregation/settings/language_groups/group_info/index.tsx
@@ -9,7 +9,6 @@ import IconLoading from '@components/icon_loading';
 import LanguageGroupMembers from '../group_members';
 import LanguageGroupDetails from '../group_details';
 import Tabs from '@components/tabs';
-import Typography from '@components/typography';
 
 const GroupInfo = (props: GroupInfoProps) => {
   const { t } = useAppTranslation();
@@ -31,10 +30,9 @@ const GroupInfo = (props: GroupInfoProps) => {
     <Dialog
       onClose={handleClose}
       open={props.open}
-      sx={{ padding: '24px', gap: '16px' }}
+      sx={{ gap: '16px' }}
+      title={t('tr_languageGroupEdit')}
     >
-      <Typography className="h2">{t('tr_languageGroupEdit')}</Typography>
-
       <Box sx={{ margin: '0 0 -16px 0', width: '100%' }}>
         <Tabs
           tabs={[

--- a/src/features/contact/index.tsx
+++ b/src/features/contact/index.tsx
@@ -1,5 +1,3 @@
-import { Box, IconButton } from '@mui/material';
-import { IconClose, IconMail } from '@icons/index';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
 import useContact from './useContact';
@@ -7,7 +5,6 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
 import TextMarkup from '@components/text_markup';
-import Typography from '@components/typography';
 import TextField from '@components/textfield';
 
 const Contact = () => {
@@ -25,36 +22,12 @@ const Contact = () => {
   } = useContact();
 
   return (
-    <Dialog open={isOpen} onClose={handleClose}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'flex-start',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <IconMail color="var(--black)" />
-        <Box
-          sx={{
-            display: 'flex',
-            padding: 'var(--radius-none)',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
-            flex: '1 0 0',
-          }}
-        >
-          <Typography className="h2">{t('tr_shareFeeback')}</Typography>
-          <IconButton
-            disableRipple
-            sx={{ padding: 0, margin: 0 }}
-            onClick={handleClose}
-          >
-            <IconClose color="var(--black)" />
-          </IconButton>
-        </Box>
-      </Box>
-
+    <Dialog
+      open={isOpen}
+      onClose={handleClose}
+      title={t('tr_shareFeeback')}
+      closable
+    >
       <TextMarkup
         content={t('tr_shareFeebackDesc')}
         className="body-regular"

--- a/src/features/dashboard/initial_setup/index.tsx
+++ b/src/features/dashboard/initial_setup/index.tsx
@@ -3,7 +3,6 @@ import useInitialSetup from './useInitialSetup';
 import BasicSettings from './basic_settings';
 import Dialog from '@components/dialog';
 import PersonRecord from './person_record';
-import Typography from '@components/typography';
 
 const InitialSetup = () => {
   const { t } = useAppTranslation();
@@ -12,11 +11,11 @@ const InitialSetup = () => {
     useInitialSetup();
 
   return (
-    <Dialog onClose={handleClose} open={open} sx={{ padding: '24px' }}>
-      <Typography className="h2">
-        {t('tr_initialOrganizedSetupTitle')}
-      </Typography>
-
+    <Dialog
+      onClose={handleClose}
+      open={open}
+      title={t('tr_initialOrganizedSetupTitle')}
+    >
       {currentStep === 1 && <BasicSettings onMove={handleMoveStep} />}
       {currentStep === 2 && <PersonRecord onPrevious={handleBackStep} />}
     </Dialog>

--- a/src/features/demo/notice/index.tsx
+++ b/src/features/demo/notice/index.tsx
@@ -3,7 +3,6 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
 import TextMarkup from '@components/text_markup';
-import Typography from '@components/typography';
 import useNotice from './useNotice';
 
 const DemoNotice = () => {
@@ -12,8 +11,7 @@ const DemoNotice = () => {
   const { handleClose, open, handleOpenRealApp } = useNotice();
 
   return (
-    <Dialog onClose={handleClose} open={open} sx={{ padding: '24px' }}>
-      <Typography className="h2">{t('tr_testAppWelcome')}</Typography>
+    <Dialog onClose={handleClose} open={open} title={t('tr_testAppWelcome')}>
       <TextMarkup
         content={t('tr_testAppWelcomeDesc')}
         className="body-regular"

--- a/src/features/meetings/assignments_delete/index.tsx
+++ b/src/features/meetings/assignments_delete/index.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
 import { AssignmentsDeleteType } from './index.types';
@@ -6,7 +5,6 @@ import useAssignmentsDelete from './useAssignmentsDelete';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 import WeekRangeSelector from '../week_range_selector';
 
 const AssignmentsDelete = ({
@@ -24,16 +22,12 @@ const AssignmentsDelete = ({
   } = useAssignmentsDelete(meeting, onClose);
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h2">
-          {t('tr_clearMultipleAssignments')}
-        </Typography>
-        <Typography color="var(--grey-400)">
-          {t('tr_clearMultipleDesc')}
-        </Typography>
-      </Box>
-
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_clearMultipleAssignments')}
+      description={t('tr_clearMultipleDesc')}
+    >
       <WeekRangeSelector
         meeting={meeting}
         onStartChange={handleSetStartWeek}

--- a/src/features/meetings/assignments_history_dialog/index.tsx
+++ b/src/features/meetings/assignments_history_dialog/index.tsx
@@ -1,10 +1,7 @@
-import { Box, IconButton } from '@mui/material';
-import { IconClose } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { AssignmentsHistoryDialogType } from './index.types';
 import AssignmentsHistory from '../assignments_history';
 import Dialog from '@components/dialog';
-import Typography from '@components/typography';
 
 const AssignmentsHistoryDialog = ({
   open,
@@ -15,26 +12,13 @@ const AssignmentsHistoryDialog = ({
   const { t } = useAppTranslation();
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Box
-        sx={{
-          display: 'flex',
-          gap: '4px',
-          alignItems: 'flex-start',
-          justifyContent: 'space-between',
-          width: '100%',
-        }}
-      >
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-          <Typography className="h2">{t('tr_assignmentsHistory')}</Typography>
-          <Typography color="var(--grey-400)">{person}</Typography>
-        </Box>
-
-        <IconButton sx={{ padding: 0 }} onClick={onClose}>
-          <IconClose color="var(--grey-400)" />
-        </IconButton>
-      </Box>
-
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_assignmentsHistory')}
+      description={person}
+      closable
+    >
       <AssignmentsHistory history={history} />
     </Dialog>
   );

--- a/src/features/meetings/assignments_history_dialog/index.tsx
+++ b/src/features/meetings/assignments_history_dialog/index.tsx
@@ -26,7 +26,7 @@ const AssignmentsHistoryDialog = ({
         }}
       >
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-          <Typography className="h3">{t('tr_assignmentsHistory')}</Typography>
+          <Typography className="h2">{t('tr_assignmentsHistory')}</Typography>
           <Typography color="var(--grey-400)">{person}</Typography>
         </Box>
 

--- a/src/features/meetings/assignments_week_delete/index.tsx
+++ b/src/features/meetings/assignments_week_delete/index.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import IconLoading from '@components/icon_loading';
 import { AssignmentsWeekDeleteType } from './index.types';
 import { useAppTranslation } from '@hooks/index';
@@ -6,7 +5,6 @@ import useAssignmentsDelete from './useAssignmentsWeekDelete';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 
 const AssignmentsWeekDelete = ({
   open,
@@ -25,16 +23,16 @@ const AssignmentsWeekDelete = ({
   );
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h2">{t('tr_clearAllAssignments')}</Typography>
-        <Typography color="var(--grey-400)">
-          {schedule_id
-            ? t('tr_clearOutgoingTalkDesc')
-            : t('tr_clearAllAssignmentsDesc')}
-        </Typography>
-      </Box>
-
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_clearAllAssignments')}
+      description={
+        schedule_id
+          ? t('tr_clearOutgoingTalkDesc')
+          : t('tr_clearAllAssignmentsDesc')
+      }
+    >
       <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}

--- a/src/features/meetings/midweek_export/index.tsx
+++ b/src/features/meetings/midweek_export/index.tsx
@@ -32,11 +32,7 @@ const MidweekExport = ({ open, onClose }: MidweekExportType) => {
   } = useMidweekExport(onClose);
 
   return (
-    <Dialog
-      onClose={onClose}
-      open={open}
-      sx={{ padding: '24px', position: 'relative' }}
-    >
+    <Dialog onClose={onClose} open={open} sx={{ position: 'relative' }}>
       <Box
         sx={{
           display: 'flex',

--- a/src/features/meetings/outgoing_talks/schedule_delete/index.tsx
+++ b/src/features/meetings/outgoing_talks/schedule_delete/index.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
 import { ScheduleDeleteType } from './index.types';
@@ -6,7 +5,6 @@ import useAssignmentsDelete from './useScheduleDelete';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 
 const ScheduleDelete = (props: ScheduleDeleteType) => {
   const { t } = useAppTranslation();
@@ -14,14 +12,12 @@ const ScheduleDelete = (props: ScheduleDeleteType) => {
   const { isProcessing, handleDeleteSchedule } = useAssignmentsDelete(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h2">{t('tr_outgoingTalkDelete')}</Typography>
-        <Typography color="var(--grey-400)">
-          {t('tr_outgoingTalkDeleteDesc')}
-        </Typography>
-      </Box>
-
+    <Dialog
+      onClose={props.onClose}
+      open={props.open}
+      title={t('tr_outgoingTalkDelete')}
+      description={t('tr_outgoingTalkDeleteDesc')}
+    >
       <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}

--- a/src/features/meetings/schedule_autofill/index.tsx
+++ b/src/features/meetings/schedule_autofill/index.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
 import { ScheduleAutofillType } from './index.types';
@@ -6,7 +5,6 @@ import useScheduleAutofill from './useScheduleAutofill';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 import WeekRangeSelector from '../week_range_selector';
 
 const ScheduleAutofillDialog = ({
@@ -24,14 +22,12 @@ const ScheduleAutofillDialog = ({
   } = useScheduleAutofill(meeting, onClose);
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h2">
-          {meeting === 'midweek' ? t('tr_autofillMM') : t('tr_autofillWM')}
-        </Typography>
-        <Typography color="var(--grey-400)">{t('tr_autofillDesc')}</Typography>
-      </Box>
-
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={meeting === 'midweek' ? t('tr_autofillMM') : t('tr_autofillWM')}
+      description={t('tr_autofillDesc')}
+    >
       <WeekRangeSelector
         meeting={meeting}
         onStartChange={handleSetStartWeek}

--- a/src/features/meetings/schedule_publish/index.tsx
+++ b/src/features/meetings/schedule_publish/index.tsx
@@ -27,7 +27,7 @@ const SchedulePublish = (props: SchedulePublishProps) => {
       sx={{ padding: '24px' }}
       header={
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-          <Typography className="h3">{t('tr_publishSchedules')}</Typography>
+          <Typography className="h2">{t('tr_publishSchedules')}</Typography>
           <Typography color="var(--grey-400)">
             {t('tr_publishSchedulesDesc')}
           </Typography>

--- a/src/features/meetings/schedule_publish/index.tsx
+++ b/src/features/meetings/schedule_publish/index.tsx
@@ -24,7 +24,6 @@ const SchedulePublish = (props: SchedulePublishProps) => {
     <Dialog
       onClose={props.onClose}
       open={props.open}
-      sx={{ padding: '24px' }}
       header={
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
           <Typography className="h2">{t('tr_publishSchedules')}</Typography>

--- a/src/features/meetings/schedule_publish/index.tsx
+++ b/src/features/meetings/schedule_publish/index.tsx
@@ -21,14 +21,34 @@ const SchedulePublish = (props: SchedulePublishProps) => {
   } = useSchedulePublish(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h3">{t('tr_publishSchedules')}</Typography>
-        <Typography color="var(--grey-400)">
-          {t('tr_publishSchedulesDesc')}
-        </Typography>
-      </Box>
-
+    <Dialog
+      onClose={props.onClose}
+      open={props.open}
+      sx={{ padding: '24px' }}
+      header={
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <Typography className="h3">{t('tr_publishSchedules')}</Typography>
+          <Typography color="var(--grey-400)">
+            {t('tr_publishSchedulesDesc')}
+          </Typography>
+        </Box>
+      }
+      actions={
+        <DialogActions>
+          <Button variant="secondary" onClick={props.onClose}>
+            {t('tr_cancel')}
+          </Button>
+          <Button
+            variant="main"
+            disabled={isProcessing}
+            onClick={handlePublishSchedule}
+            endIcon={isProcessing && <IconLoading />}
+          >
+            {t('tr_publish')}
+          </Button>
+        </DialogActions>
+      }
+    >
       <Stack
         direction="row"
         spacing="24px"
@@ -45,20 +65,6 @@ const SchedulePublish = (props: SchedulePublishProps) => {
           />
         ))}
       </Stack>
-
-      <DialogActions>
-        <Button variant="secondary" onClick={props.onClose}>
-          {t('tr_cancel')}
-        </Button>
-        <Button
-          variant="main"
-          disabled={isProcessing}
-          onClick={handlePublishSchedule}
-          endIcon={isProcessing && <IconLoading />}
-        >
-          {t('tr_publish')}
-        </Button>
-      </DialogActions>
     </Dialog>
   );
 };

--- a/src/features/meetings/weekend_editor/song_selector/index.tsx
+++ b/src/features/meetings/weekend_editor/song_selector/index.tsx
@@ -36,7 +36,7 @@ const SongSelector = (props: SongSelectorProps) => {
             width: '100%',
           }}
         >
-          <Typography className="h3">{t('tr_selectSong')}</Typography>
+          <Typography className="h2">{t('tr_selectSong')}</Typography>
 
           <IconButton sx={{ padding: 0 }} onClick={handleClose}>
             <IconClose color="var(--grey-400)" />

--- a/src/features/meetings/weekend_editor/song_selector/index.tsx
+++ b/src/features/meetings/weekend_editor/song_selector/index.tsx
@@ -25,7 +25,7 @@ const SongSelector = (props: SongSelectorProps) => {
   } = useSongSelector(props);
 
   return (
-    <Dialog onClose={handleClose} open={selectorOpen} sx={{ padding: '24px' }}>
+    <Dialog onClose={handleClose} open={selectorOpen}>
       <Stack spacing="16px">
         <Box
           sx={{

--- a/src/features/meetings/weekend_editor/speakers_catalog/index.tsx
+++ b/src/features/meetings/weekend_editor/speakers_catalog/index.tsx
@@ -36,7 +36,7 @@ const SpeakersCatalog = (props: SpeakersCatalogType) => {
       >
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-            <Typography className="h3">{t('tr_speakersCatalog')}</Typography>
+            <Typography className="h2">{t('tr_speakersCatalog')}</Typography>
             <Typography className="h4" color="var(--grey-400)">
               {t('tr_speakersWithCount', { speakersCount: count })}
             </Typography>

--- a/src/features/meetings/weekend_editor/speakers_catalog/index.tsx
+++ b/src/features/meetings/weekend_editor/speakers_catalog/index.tsx
@@ -24,7 +24,7 @@ const SpeakersCatalog = (props: SpeakersCatalogType) => {
   } = useSpeakersCatalog(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
+    <Dialog onClose={props.onClose} open={props.open}>
       <Box
         sx={{
           display: 'flex',

--- a/src/features/meetings/weekend_export/index.tsx
+++ b/src/features/meetings/weekend_export/index.tsx
@@ -25,11 +25,7 @@ const WeekendExport = ({ open, onClose }: WeekendExportType) => {
   } = useWeekendExport(onClose);
 
   return (
-    <Dialog
-      onClose={onClose}
-      open={open}
-      sx={{ padding: '24px', position: 'relative' }}
-    >
+    <Dialog onClose={onClose} open={open} sx={{ position: 'relative' }}>
       <Box
         sx={{
           display: 'flex',

--- a/src/features/ministry/report/form_S4/bible_studies/editor/index.tsx
+++ b/src/features/ministry/report/form_S4/bible_studies/editor/index.tsx
@@ -1,13 +1,9 @@
-import { Box } from '@mui/material';
-import { IconClose } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import { BibleStudyEditorProps } from './index.types';
 import useBibleStudy from './useBibleStudy';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import IconButton from '@components/icon_button';
-import Typography from '@components/typography';
 import TextField from '@components/textfield';
 
 const BibleStudyEditor = (props: BibleStudyEditorProps) => {
@@ -21,22 +17,9 @@ const BibleStudyEditor = (props: BibleStudyEditorProps) => {
       open={props.open}
       onClose={props.onClose}
       sx={{ padding: '12px 24px', alignItems: 'stretch' }}
+      title={props.bibleStudy ? t('tr_editBibleStudy') : t('tr_addNewStudy')}
+      closable
     >
-      <Box
-        sx={{
-          alignItems: 'center',
-          display: 'flex',
-          justifyContent: 'space-between',
-        }}
-      >
-        <Typography className="h2">
-          {props.bibleStudy ? t('tr_editBibleStudy') : t('tr_addNewStudy')}
-        </Typography>
-        <IconButton onClick={props.onClose}>
-          <IconClose color="var(--black)" />
-        </IconButton>
-      </Box>
-
       <TextField
         label={t('tr_name')}
         value={value}

--- a/src/features/ministry/report/form_S4/submit_report/index.tsx
+++ b/src/features/ministry/report/form_S4/submit_report/index.tsx
@@ -1,5 +1,3 @@
-import { Box } from '@mui/material';
-import { IconClose } from '@components/icons';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
 import { SubmitReportProps } from './index.types';
@@ -7,7 +5,6 @@ import useSubmitReport from './useSubmitReport';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import IconButton from '@components/icon_button';
 import Typography from '@components/typography';
 
 const SubmitReport = (props: SubmitReportProps) => {
@@ -21,29 +18,16 @@ const SubmitReport = (props: SubmitReportProps) => {
   } = useSubmitReport(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
-      <Box
-        sx={{
-          display: 'flex',
-          gap: '4px',
-          alignItems: 'flex-start',
-          justifyContent: 'space-between',
-          width: '100%',
-        }}
-      >
-        <Typography className="h2">
-          {minutes_remains === 0
-            ? t('tr_btnSubmitReport')
-            : t('tr_extraTime', { ministryTime: minutes_remains })}
-        </Typography>
-
-        {minutes_remains > 0 && (
-          <IconButton sx={{ padding: 0 }} onClick={props.onClose}>
-            <IconClose color="var(--grey-400)" />
-          </IconButton>
-        )}
-      </Box>
-
+    <Dialog
+      onClose={props.onClose}
+      open={props.open}
+      title={
+        minutes_remains === 0
+          ? t('tr_btnSubmitReport')
+          : t('tr_extraTime', { ministryTime: minutes_remains })
+      }
+      closable={minutes_remains > 0}
+    >
       <Typography color="var(--grey-400)">
         {minutes_remains === 0
           ? t('tr_submitReportDesc')

--- a/src/features/ministry/report/form_S4/withdraw_report/index.tsx
+++ b/src/features/ministry/report/form_S4/withdraw_report/index.tsx
@@ -5,7 +5,6 @@ import useWithdrawReport from './useWithdrawReport';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 
 const WithdrawReport = (props: WithdrawReportProps) => {
   const { t } = useAppTranslation();
@@ -13,13 +12,12 @@ const WithdrawReport = (props: WithdrawReportProps) => {
   const { isProcessing, handleWithdrawal } = useWithdrawReport(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
-      <Typography className="h2">{t('tr_undoSubmission')}</Typography>
-
-      <Typography color="var(--grey-400)">
-        {t('tr_undoSubmissionDesc')}
-      </Typography>
-
+    <Dialog
+      onClose={props.onClose}
+      open={props.open}
+      title={t('tr_undoSubmission')}
+      description={t('tr_undoSubmissionDesc')}
+    >
       <DialogActions>
         <Button
           variant="secondary"

--- a/src/features/ministry/report/ministry_timer/add_time_dialog/index.tsx
+++ b/src/features/ministry/report/ministry_timer/add_time_dialog/index.tsx
@@ -6,7 +6,6 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
 import TimePickerSlider from '@components/time_picker_slider';
-import Typography from '@components/typography';
 
 const AddTimeDialog = (props: AddTimeDialogProps) => {
   const { t } = useAppTranslation();
@@ -14,14 +13,12 @@ const AddTimeDialog = (props: AddTimeDialogProps) => {
   const { handleAddTime, handleValueChange, value } = useAddTimeDialog(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        <Typography className="h2">{t('tr_timeInService')}</Typography>
-        <Typography color="var(--grey-400)">
-          {t('tr_timeInServiceDesc')}
-        </Typography>
-      </Box>
-
+    <Dialog
+      onClose={props.onClose}
+      open={props.open}
+      title={t('tr_timeInService')}
+      description={t('tr_timeInServiceDesc')}
+    >
       <Box
         sx={{
           width: '100%',

--- a/src/features/my_profile/logout_confirm/index.tsx
+++ b/src/features/my_profile/logout_confirm/index.tsx
@@ -4,7 +4,6 @@ import useLogoutConfirm from './useLogoutConfirm';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 
 const LogoutConfirm = ({ open, onClose }: LogoutConfirmType) => {
   const { t } = useAppTranslation();
@@ -12,11 +11,12 @@ const LogoutConfirm = ({ open, onClose }: LogoutConfirmType) => {
   const { handleLogout } = useLogoutConfirm();
 
   return (
-    <Dialog onClose={onClose} open={open}>
-      <Typography className="h2">{t('tr_logoutClearData')}</Typography>
-      <Typography className="body-regular" color="var(--grey-400)">
-        {t('tr_logoutClearDataDesc')}
-      </Typography>
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_logoutClearData')}
+      description={t('tr_logoutClearDataDesc')}
+    >
       <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}

--- a/src/features/my_profile/security/delete_account/index.tsx
+++ b/src/features/my_profile/security/delete_account/index.tsx
@@ -1,4 +1,3 @@
-import { Stack } from '@mui/material';
 import { IconEncryptionKey } from '@components/icons';
 import IconLoading from '@components/icon_loading';
 import { useAppTranslation } from '@hooks/index';
@@ -8,7 +7,6 @@ import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
 import TextField from '@components/textfield';
-import Typography from '@components/typography';
 import WaitingLoader from '@components/waiting_loader';
 
 const DeleteAccount = ({ open, onClose }: DeleteAccountProps) => {
@@ -27,17 +25,12 @@ const DeleteAccount = ({ open, onClose }: DeleteAccountProps) => {
   } = useDeleteAccount(onClose);
 
   return (
-    <Dialog onClose={onClose} open={open}>
-      <Stack spacing="16px">
-        <Typography className="h2">{t('tr_deleteAccount')}</Typography>
-
-        {!isLoading && (
-          <Typography className="body-regular" color="var(--grey-400)">
-            {desc}
-          </Typography>
-        )}
-      </Stack>
-
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_deleteAccount')}
+      description={desc}
+    >
       {isLoading && <WaitingLoader variant="standard" size={72} />}
 
       {!isLoading && isDeleteCong && (

--- a/src/features/my_profile/security/mfaDisable/index.tsx
+++ b/src/features/my_profile/security/mfaDisable/index.tsx
@@ -1,9 +1,7 @@
-import { Box } from '@mui/material';
 import IconLoading from '@components/icon_loading';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import useMFADisable from './useMFADisable';
 
@@ -18,14 +16,12 @@ const MFADisable = ({ open, onClose }: MFADisableType) => {
   const { handleDisable2FA, isProcessing } = useMFADisable(onClose);
 
   return (
-    <Dialog onClose={onClose} open={open}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-        <Typography className="h2">{t('tr_2FADisable')}</Typography>
-        <Typography className="body-regular" color="var(--grey-400)">
-          {t('tr_2FADisableDesc')}
-        </Typography>
-      </Box>
-
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_2FADisable')}
+      description={t('tr_2FADisableDesc')}
+    >
       <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}

--- a/src/features/persons/disqualify/index.tsx
+++ b/src/features/persons/disqualify/index.tsx
@@ -1,8 +1,6 @@
-import { Box } from '@mui/material';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import { PersonDisqualifyConfirmType } from './index.types';
 
@@ -14,13 +12,12 @@ const PersonDisqualifyConfirm = ({
   const { t } = useAppTranslation();
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-        <Typography className="h2">{t('tr_markDisqualifiedTitle')}</Typography>
-        <Typography className="body-regular" color="var(--grey-400)">
-          {t('tr_markDisqualifiedDesc')}
-        </Typography>
-      </Box>
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_markDisqualifiedTitle')}
+      description={t('tr_markDisqualifiedDesc')}
+    >
       <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}

--- a/src/features/persons/import_export/index.tsx
+++ b/src/features/persons/import_export/index.tsx
@@ -49,7 +49,7 @@ const ImportExport = (props: ImportExportType) => {
   };
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
+    <Dialog onClose={props.onClose} open={props.open}>
       {state === 'import/export' && (
         <Stack
           spacing="16px"

--- a/src/features/persons/list/person_delete/index.tsx
+++ b/src/features/persons/list/person_delete/index.tsx
@@ -1,7 +1,6 @@
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import { DeletePersonConfirmType } from './index.types';
 
@@ -13,11 +12,12 @@ const DeletePersonConfirm = ({
   const { t } = useAppTranslation();
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Typography className="h2">{t('tr_deletePerson')}</Typography>
-      <Typography className="body-regular" color="var(--grey-400)">
-        {t('tr_deletePersonConfirmation')}
-      </Typography>
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_deletePerson')}
+      description={t('tr_deletePersonConfirmation')}
+    >
       <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}

--- a/src/features/persons/qualify/index.tsx
+++ b/src/features/persons/qualify/index.tsx
@@ -1,8 +1,6 @@
-import { Box } from '@mui/material';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import { PersonQualifyConfirmType } from './index.types';
 
@@ -14,13 +12,12 @@ const PersonQualifyConfirm = ({
   const { t } = useAppTranslation();
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-        <Typography className="h2">{t('tr_markQualifiedTitle')}</Typography>
-        <Typography className="body-regular" color="var(--grey-400)">
-          {t('tr_markQualifiedDesc')}
-        </Typography>
-      </Box>
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_markQualifiedTitle')}
+      description={t('tr_markQualifiedDesc')}
+    >
       <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}

--- a/src/features/persons/speakers_catalog/my_congregation/visibility_toggle/visibility_off/index.tsx
+++ b/src/features/persons/speakers_catalog/my_congregation/visibility_toggle/visibility_off/index.tsx
@@ -15,7 +15,7 @@ const VisibilityOffConfirm = ({
   const { t } = useAppTranslation();
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
+    <Dialog onClose={onClose} open={open}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
         <Typography className="h2">{t('tr_outgoingSpeakersHide')}</Typography>
         <TextMarkup

--- a/src/features/persons/speakers_catalog/other_congregations/congregation_add/index.tsx
+++ b/src/features/persons/speakers_catalog/other_congregations/congregation_add/index.tsx
@@ -37,7 +37,7 @@ const CongregationAdd = ({ onClose, open }: CongregationAddType) => {
   } = useCongregationAdd(onClose);
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
+    <Dialog onClose={onClose} open={open}>
       {isFindCongregation && (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
           <Typography className="h2">{t('tr_addCongregation')}</Typography>

--- a/src/features/persons/speakers_catalog/song_add_popup/index.tsx
+++ b/src/features/persons/speakers_catalog/song_add_popup/index.tsx
@@ -1,9 +1,7 @@
-import { Box } from '@mui/material';
 import { PopupSongAddType } from './index.types';
 import { useAppTranslation } from '@hooks/index';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
-import Typography from '@components/typography';
 import SongsTalk from '../songs_talk';
 
 const PopupSongAdd = ({
@@ -17,33 +15,23 @@ const PopupSongAdd = ({
   const { t } = useAppTranslation();
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-        <Typography className="h2">{t('tr_publicTalkAddSongs')}</Typography>
-        <Typography className="body-regular" color="var(--grey-400)">
-          {t('tr_publicTalkAddSongsDesc')}
-        </Typography>
-      </Box>
-
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_publicTalkAddSongs')}
+      description={t('tr_publicTalkAddSongsDesc')}
+      actions={
+        <Button variant="main" onClick={onClose} sx={{ width: '100%' }}>
+          {t('tr_done')}
+        </Button>
+      }
+    >
       <SongsTalk
         onChange={onChange}
         onDelete={onDelete}
         songs={songs}
         talk={talk}
       />
-
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          width: '100%',
-        }}
-      >
-        <Button variant="main" onClick={onClose}>
-          {t('tr_done')}
-        </Button>
-      </Box>
     </Dialog>
   );
 };

--- a/src/features/quick_settings/index.tsx
+++ b/src/features/quick_settings/index.tsx
@@ -15,7 +15,7 @@ const QuickSettings = ({
   const { t } = useAppTranslation();
 
   return (
-    <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
+    <Dialog onClose={onClose} open={open}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
         <Typography className="h2">
           {t('tr_quickSettings')} – {title}

--- a/src/features/quick_settings/index.tsx
+++ b/src/features/quick_settings/index.tsx
@@ -17,7 +17,7 @@ const QuickSettings = ({
   return (
     <Dialog onClose={onClose} open={open} sx={{ padding: '24px' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-        <Typography className="h3">
+        <Typography className="h2">
           {t('tr_quickSettings')} – {title}
         </Typography>
         <Typography color="var(--grey-400)">

--- a/src/features/reports/branch_office/submit_report/index.tsx
+++ b/src/features/reports/branch_office/submit_report/index.tsx
@@ -1,11 +1,9 @@
-import { Stack } from '@mui/material';
 import { useAppTranslation } from '@hooks/index';
 import { SubmitReportProps } from './index.types';
 import useSubmitReport from './useSubmitReport';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 
 const SubmitReport = (props: SubmitReportProps) => {
   const { t } = useAppTranslation();
@@ -13,15 +11,12 @@ const SubmitReport = (props: SubmitReportProps) => {
   const { handleSubmitted } = useSubmitReport(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
-      <Stack spacing="16px">
-        <Typography className="h2">{t('tr_markAsSubmitted')}</Typography>
-
-        <Typography color="var(--grey-400)">
-          {t('tr_markToBranchOfficeDesc')}
-        </Typography>
-      </Stack>
-
+    <Dialog
+      onClose={props.onClose}
+      open={props.open}
+      title={t('tr_markAsSubmitted')}
+      description={t('tr_markToBranchOfficeDesc')}
+    >
       <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}

--- a/src/features/reports/branch_office/withdraw_report/index.tsx
+++ b/src/features/reports/branch_office/withdraw_report/index.tsx
@@ -1,11 +1,9 @@
-import { Stack } from '@mui/material';
 import { useAppTranslation } from '@hooks/index';
 import { WithdrawReportProps } from './index.types';
 import useSubmitReport from './useWithdrawReport';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 
 const WithdrawReport = (props: WithdrawReportProps) => {
   const { t } = useAppTranslation();
@@ -13,15 +11,12 @@ const WithdrawReport = (props: WithdrawReportProps) => {
   const { handleWithdraw } = useSubmitReport(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
-      <Stack spacing="16px">
-        <Typography className="h2">{t('tr_undoSubmission')}</Typography>
-
-        <Typography color="var(--grey-400)">
-          {t('tr_undoBranchReportSubmissionDesc')}
-        </Typography>
-      </Stack>
-
+    <Dialog
+      onClose={props.onClose}
+      open={props.open}
+      title={t('tr_undoSubmission')}
+      description={t('tr_undoBranchReportSubmissionDesc')}
+    >
       <DialogActions>
         <Button variant="secondary" onClick={props.onClose}>
           {t('tr_cancel')}

--- a/src/features/reports/publisher_records/export_S21/index.tsx
+++ b/src/features/reports/publisher_records/export_S21/index.tsx
@@ -16,7 +16,7 @@ const ExportS21 = (props: ExportS21Props) => {
   } = useExportS21(props);
 
   return (
-    <Dialog onClose={props.onClose} open={props.open} sx={{ padding: '24px' }}>
+    <Dialog onClose={props.onClose} open={props.open}>
       {allOpen && (
         <AllRecords
           type={type}

--- a/src/features/reports/publisher_records_details/report_details/index.tsx
+++ b/src/features/reports/publisher_records_details/report_details/index.tsx
@@ -28,7 +28,7 @@ const ReportDetails = (props: ReportDetailsProps) => {
   } = useReportDetails(props);
 
   return (
-    <Dialog open={props.open} onClose={props.onClose} sx={{ padding: '24px' }}>
+    <Dialog open={props.open} onClose={props.onClose}>
       <Typography className="h2">
         {t('tr_fieldReportEdit')} ({reportMonth})
       </Typography>

--- a/src/features/support/index.tsx
+++ b/src/features/support/index.tsx
@@ -1,9 +1,9 @@
-import { Box, Divider, IconButton } from '@mui/material';
+import { Box, Divider } from '@mui/material';
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import TextMarkup from '@components/text_markup';
 import Typography from '@components/typography';
-import { IconClose, IconDonate, IconDutiesDistribution } from '@icons/index';
+import { IconDonate, IconDutiesDistribution } from '@icons/index';
 import { useAppTranslation } from '@hooks/index';
 import useSupport from './useSupport';
 
@@ -13,7 +13,12 @@ const Support = () => {
   const { handleClose, isOpen, handleOpenDonate, handleOpenDoc } = useSupport();
 
   return (
-    <Dialog open={isOpen} onClose={handleClose}>
+    <Dialog
+      open={isOpen}
+      onClose={handleClose}
+      title={t('tr_supportApp')}
+      closable
+    >
       <Box
         sx={{
           display: 'flex',
@@ -22,27 +27,6 @@ const Support = () => {
           width: '100%',
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: '8px' }}>
-          <IconDonate color="var(--black)" />
-          <Box
-            sx={{
-              display: 'flex',
-              padding: 'var(--radius-none)',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-              flex: '1 0 0',
-            }}
-          >
-            <Typography className="h2">{t('tr_supportApp')}</Typography>
-            <IconButton
-              disableRipple
-              sx={{ padding: 0, margin: 0 }}
-              onClick={handleClose}
-            >
-              <IconClose color="var(--black)" />
-            </IconButton>
-          </Box>
-        </Box>
         <TextMarkup content={t('tr_supportAppDesc')} className="body-regular" />
       </Box>
 

--- a/src/features/theme_switcher/themeChangeConfirm/index.tsx
+++ b/src/features/theme_switcher/themeChangeConfirm/index.tsx
@@ -1,7 +1,6 @@
 import Button from '@components/button';
 import Dialog from '@components/dialog';
 import DialogActions from '@components/dialog_actions';
-import Typography from '@components/typography';
 import { useAppTranslation } from '@hooks/index';
 import { ThemeChangeConfirmType } from './index.types';
 
@@ -13,11 +12,12 @@ const ThemeChangeConfirm = ({
   const { t } = useAppTranslation();
 
   return (
-    <Dialog onClose={onClose} open={open}>
-      <Typography className="h2">{t('tr_themeFollowOSDisable')}</Typography>
-      <Typography className="body-regular" color="var(--grey-400)">
-        {t('tr_themeFollowOSDisableDesc')}
-      </Typography>
+    <Dialog
+      onClose={onClose}
+      open={open}
+      title={t('tr_themeFollowOSDisable')}
+      description={t('tr_themeFollowOSDisableDesc')}
+    >
       <DialogActions>
         <Button variant="secondary" onClick={onClose}>
           {t('tr_cancel')}

--- a/src/features/whats_new/index.tsx
+++ b/src/features/whats_new/index.tsx
@@ -26,7 +26,7 @@ const WhatsNew = () => {
     <Dialog
       open={open}
       onClose={handleClose}
-      sx={{ padding: '24px', position: 'relative' }}
+      sx={{ position: 'relative' }}
       title={t('tr_newOrganizedUpdate')}
       description={t('tr_newOrganizedUpdateDesc')}
       closable={!isLoading && images.length > 0}

--- a/src/features/whats_new/index.tsx
+++ b/src/features/whats_new/index.tsx
@@ -31,17 +31,24 @@ const WhatsNew = () => {
       open={open}
       onClose={handleClose}
       sx={{ padding: '24px', position: 'relative' }}
-    >
-      <Stack spacing="8px" width="100%">
+      header={
         <Box
           sx={{
             display: 'flex',
             flexDirection: 'row',
             justifyContent: 'space-between',
-            alignItems: 'center',
+            alignItems: 'flex-start',
+            gap: '8px',
+            width: '100%',
           }}
         >
-          <Typography className="h2">{t('tr_newOrganizedUpdate')}</Typography>
+          <Stack spacing="2px">
+            <Typography className="h2">{t('tr_newOrganizedUpdate')}</Typography>
+
+            <Typography color="var(--grey-400)">
+              {t('tr_newOrganizedUpdateDesc')}
+            </Typography>
+          </Stack>
 
           {!isLoading && images.length > 0 && (
             <IconButton onClick={handleClose}>
@@ -49,12 +56,19 @@ const WhatsNew = () => {
             </IconButton>
           )}
         </Box>
-
-        <Typography color="var(--grey-400)">
-          {t('tr_newOrganizedUpdateDesc')}
-        </Typography>
-      </Stack>
-
+      }
+      actions={
+        !isLoading && (
+          <ButtonsAction
+            slides={images}
+            current={currentImage}
+            onClose={handleClose}
+            onNext={handleNextAction}
+            onBack={handleBackAction}
+          />
+        )
+      }
+    >
       {isLoading && <WaitingLoader size={72} variant="standard" />}
 
       {!isLoading && (
@@ -74,14 +88,6 @@ const WhatsNew = () => {
               showHeader={images.length > 0}
             />
           )}
-
-          <ButtonsAction
-            slides={images}
-            current={currentImage}
-            onClose={handleClose}
-            onNext={handleNextAction}
-            onBack={handleBackAction}
-          />
         </>
       )}
     </Dialog>

--- a/src/features/whats_new/index.tsx
+++ b/src/features/whats_new/index.tsx
@@ -1,13 +1,9 @@
-import { Box, Stack } from '@mui/material';
-import { IconClose } from '@components/icons';
 import { useAppTranslation } from '@hooks/index';
 import useWhatsNew from './useWhatsNew';
 import ButtonsAction from './buttons_action';
 import Dialog from '@components/dialog';
-import IconButton from '@components/icon_button';
 import ImageViewer from './image_viewer';
 import ImprovementsList from './improvements_list';
-import Typography from '@components/typography';
 import WaitingLoader from '@components/waiting_loader';
 
 const WhatsNew = () => {
@@ -31,32 +27,9 @@ const WhatsNew = () => {
       open={open}
       onClose={handleClose}
       sx={{ padding: '24px', position: 'relative' }}
-      header={
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'row',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
-            gap: '8px',
-            width: '100%',
-          }}
-        >
-          <Stack spacing="2px">
-            <Typography className="h2">{t('tr_newOrganizedUpdate')}</Typography>
-
-            <Typography color="var(--grey-400)">
-              {t('tr_newOrganizedUpdateDesc')}
-            </Typography>
-          </Stack>
-
-          {!isLoading && images.length > 0 && (
-            <IconButton onClick={handleClose}>
-              <IconClose color="var(--black)" />
-            </IconButton>
-          )}
-        </Box>
-      }
+      title={t('tr_newOrganizedUpdate')}
+      description={t('tr_newOrganizedUpdateDesc')}
+      closable={!isLoading && images.length > 0}
       actions={
         !isLoading && (
           <ButtonsAction

--- a/src/global/index.css
+++ b/src/global/index.css
@@ -177,3 +177,212 @@ span .text-markup:last-child {
 body iframe {
   opacity: 0;
 }
+
+/* Fades a scrollable element at the edges that hide content. The stops follow
+   a curve that flattens at both ends, so neither the edge itself nor the point
+   where the fade meets the content reads as a line. The scrollbar keeps a strip
+   of its own and is never faded. `--scroll-fade-top` and `--scroll-fade-bottom`
+   are how much of each fade shows, from 0 to 1, `--scroll-fade-size` how far it
+   reaches, and `--scroll-fade-gutter` the width of the scrollbar. */
+.scroll-fade-y {
+  /* 48px, but never more than a quarter of a short scroll area: a phone in
+     landscape can leave a dialog barely 110px of content, and two full fades
+     would swallow most of it */
+  --scroll-fade-size: min(48px, 25%);
+  --scroll-fade-gutter: 0px;
+
+  -webkit-mask-image:
+    linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 1)) 0px,
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9988))
+        calc(var(--scroll-fade-size) * 0.05),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9914))
+        calc(var(--scroll-fade-size) * 0.1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9734))
+        calc(var(--scroll-fade-size) * 0.15),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9421))
+        calc(var(--scroll-fade-size) * 0.2),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.8965))
+        calc(var(--scroll-fade-size) * 0.25),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.8369))
+        calc(var(--scroll-fade-size) * 0.3),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.7648))
+        calc(var(--scroll-fade-size) * 0.35),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.6826))
+        calc(var(--scroll-fade-size) * 0.4),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.5931))
+        calc(var(--scroll-fade-size) * 0.45),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.5))
+        calc(var(--scroll-fade-size) * 0.5),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.4069))
+        calc(var(--scroll-fade-size) * 0.55),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.3174))
+        calc(var(--scroll-fade-size) * 0.6),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.2352))
+        calc(var(--scroll-fade-size) * 0.65),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.1631))
+        calc(var(--scroll-fade-size) * 0.7),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.1035))
+        calc(var(--scroll-fade-size) * 0.75),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0579))
+        calc(var(--scroll-fade-size) * 0.8),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0266))
+        calc(var(--scroll-fade-size) * 0.85),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0086))
+        calc(var(--scroll-fade-size) * 0.9),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0012))
+        calc(var(--scroll-fade-size) * 0.95),
+      #000 calc(var(--scroll-fade-size) * 1),
+      #000 calc(100% - var(--scroll-fade-size) * 1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0012))
+        calc(100% - var(--scroll-fade-size) * 0.95),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0086))
+        calc(100% - var(--scroll-fade-size) * 0.9),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0266))
+        calc(100% - var(--scroll-fade-size) * 0.85),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0579))
+        calc(100% - var(--scroll-fade-size) * 0.8),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.1035))
+        calc(100% - var(--scroll-fade-size) * 0.75),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.1631))
+        calc(100% - var(--scroll-fade-size) * 0.7),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.2352))
+        calc(100% - var(--scroll-fade-size) * 0.65),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.3174))
+        calc(100% - var(--scroll-fade-size) * 0.6),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.4069))
+        calc(100% - var(--scroll-fade-size) * 0.55),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.5))
+        calc(100% - var(--scroll-fade-size) * 0.5),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.5931))
+        calc(100% - var(--scroll-fade-size) * 0.45),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.6826))
+        calc(100% - var(--scroll-fade-size) * 0.4),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.7648))
+        calc(100% - var(--scroll-fade-size) * 0.35),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.8369))
+        calc(100% - var(--scroll-fade-size) * 0.3),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.8965))
+        calc(100% - var(--scroll-fade-size) * 0.25),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9421))
+        calc(100% - var(--scroll-fade-size) * 0.2),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9734))
+        calc(100% - var(--scroll-fade-size) * 0.15),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9914))
+        calc(100% - var(--scroll-fade-size) * 0.1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9988))
+        calc(100% - var(--scroll-fade-size) * 0.05),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 1)) 100%
+    ),
+    linear-gradient(#000, #000);
+  -webkit-mask-size:
+    calc(100% - var(--scroll-fade-gutter)) 100%,
+    var(--scroll-fade-gutter) 100%;
+  -webkit-mask-position:
+    left top,
+    right top;
+  -webkit-mask-repeat: no-repeat;
+  mask-image:
+    linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 1)) 0px,
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9988))
+        calc(var(--scroll-fade-size) * 0.05),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9914))
+        calc(var(--scroll-fade-size) * 0.1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9734))
+        calc(var(--scroll-fade-size) * 0.15),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.9421))
+        calc(var(--scroll-fade-size) * 0.2),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.8965))
+        calc(var(--scroll-fade-size) * 0.25),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.8369))
+        calc(var(--scroll-fade-size) * 0.3),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.7648))
+        calc(var(--scroll-fade-size) * 0.35),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.6826))
+        calc(var(--scroll-fade-size) * 0.4),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.5931))
+        calc(var(--scroll-fade-size) * 0.45),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.5))
+        calc(var(--scroll-fade-size) * 0.5),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.4069))
+        calc(var(--scroll-fade-size) * 0.55),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.3174))
+        calc(var(--scroll-fade-size) * 0.6),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.2352))
+        calc(var(--scroll-fade-size) * 0.65),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.1631))
+        calc(var(--scroll-fade-size) * 0.7),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.1035))
+        calc(var(--scroll-fade-size) * 0.75),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0579))
+        calc(var(--scroll-fade-size) * 0.8),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0266))
+        calc(var(--scroll-fade-size) * 0.85),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0086))
+        calc(var(--scroll-fade-size) * 0.9),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-top, 0) * 0.0012))
+        calc(var(--scroll-fade-size) * 0.95),
+      #000 calc(var(--scroll-fade-size) * 1),
+      #000 calc(100% - var(--scroll-fade-size) * 1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0012))
+        calc(100% - var(--scroll-fade-size) * 0.95),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0086))
+        calc(100% - var(--scroll-fade-size) * 0.9),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0266))
+        calc(100% - var(--scroll-fade-size) * 0.85),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.0579))
+        calc(100% - var(--scroll-fade-size) * 0.8),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.1035))
+        calc(100% - var(--scroll-fade-size) * 0.75),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.1631))
+        calc(100% - var(--scroll-fade-size) * 0.7),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.2352))
+        calc(100% - var(--scroll-fade-size) * 0.65),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.3174))
+        calc(100% - var(--scroll-fade-size) * 0.6),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.4069))
+        calc(100% - var(--scroll-fade-size) * 0.55),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.5))
+        calc(100% - var(--scroll-fade-size) * 0.5),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.5931))
+        calc(100% - var(--scroll-fade-size) * 0.45),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.6826))
+        calc(100% - var(--scroll-fade-size) * 0.4),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.7648))
+        calc(100% - var(--scroll-fade-size) * 0.35),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.8369))
+        calc(100% - var(--scroll-fade-size) * 0.3),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.8965))
+        calc(100% - var(--scroll-fade-size) * 0.25),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9421))
+        calc(100% - var(--scroll-fade-size) * 0.2),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9734))
+        calc(100% - var(--scroll-fade-size) * 0.15),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9914))
+        calc(100% - var(--scroll-fade-size) * 0.1),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 0.9988))
+        calc(100% - var(--scroll-fade-size) * 0.05),
+      rgba(0, 0, 0, calc(1 - var(--scroll-fade-bottom, 0) * 1)) 100%
+    ),
+    linear-gradient(#000, #000);
+  mask-size:
+    calc(100% - var(--scroll-fade-gutter)) 100%,
+    var(--scroll-fade-gutter) 100%;
+  mask-position:
+    left top,
+    right top;
+  mask-repeat: no-repeat;
+}
+
+/* the scrollbar sits on the other side when the interface is right to left */
+[dir='rtl'] .scroll-fade-y {
+  -webkit-mask-position:
+    right top,
+    left top;
+  mask-position:
+    right top,
+    left top;
+}

--- a/src/global/index.css
+++ b/src/global/index.css
@@ -1,4 +1,11 @@
 :root {
+  /* dialogs: the surrounding padding, the gap between the rows inside, and
+     the gap under a pinned title */
+  --dialog-padding: 24px;
+  --dialog-gap: 24px;
+  --dialog-gap-mobile: 16px;
+  --dialog-header-gap: 8px;
+
   --message-glow-small-offset-y: 4px;
   --message-glow-small-blur: 12px;
   --message-glow-small: 0px var(--message-glow-small-offset-y)

--- a/src/global/index.css
+++ b/src/global/index.css
@@ -179,15 +179,11 @@ body iframe {
 }
 
 /* Fades a scrollable element at the edges that hide content. The stops follow
-   a curve that flattens at both ends, so neither the edge itself nor the point
-   where the fade meets the content reads as a line. The scrollbar keeps a strip
-   of its own and is never faded. `--scroll-fade-top` and `--scroll-fade-bottom`
-   are how much of each fade shows, from 0 to 1, `--scroll-fade-size` how far it
-   reaches, and `--scroll-fade-gutter` the width of the scrollbar. */
+   a curve that flattens at both ends: a straight ramp reads as a line rather
+   than a fade. The scrollbar keeps a strip of its own and is never faded. */
 .scroll-fade-y {
-  /* 48px, but never more than a quarter of a short scroll area: a phone in
-     landscape can leave a dialog barely 110px of content, and two full fades
-     would swallow most of it */
+  /* capped: a phone in landscape can leave a dialog 110px of content, and two
+     full fades would swallow most of it */
   --scroll-fade-size: min(48px, 25%);
   --scroll-fade-gutter: 0px;
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { default as useAppTranslation } from './useAppTranslation';
 export { default as useBreakpoints } from './useBreakpoints';
+export { default as useScrollFade } from './useScrollFade';
 export { default as useIsTouchDevice } from './useIsTouchDevice';
 export { default as useFirebaseAuth } from './useFirebaseAuth';
 export { default as useGlobal } from './useGlobal';

--- a/src/hooks/useScrollFade.tsx
+++ b/src/hooks/useScrollFade.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+// the scroll distance over which an edge reveals its fade
+const REVEAL = 8;
+
+/**
+ * Reveals the `scroll-fade-y` fades of a scrollable element, by how far its
+ * content has scrolled past each edge: none at rest, full once content is
+ * hidden.
+ *
+ * The amounts are written straight to the CSS variables the fades read, so
+ * scrolling neither re-renders nor waits on a transition.
+ *
+ * The element is attached through a callback ref: content mounted late, such
+ * as a dialog opening or an image arriving, is picked up on its own.
+ */
+const useScrollFade = () => {
+  const cleanup = useRef<VoidFunction>(null);
+
+  const ref = useCallback((el: HTMLDivElement | null) => {
+    cleanup.current?.();
+    cleanup.current = null;
+
+    if (!el) return;
+
+    let frame = 0;
+
+    const update = () => {
+      const hiddenAbove = el.scrollTop;
+      const hiddenBelow = el.scrollHeight - el.clientHeight - el.scrollTop;
+
+      const reveal = (hidden: number) =>
+        Math.min(Math.max(hidden, 0) / REVEAL, 1).toFixed(3);
+
+      el.style.setProperty('--scroll-fade-top', reveal(hiddenAbove));
+      el.style.setProperty('--scroll-fade-bottom', reveal(hiddenBelow));
+    };
+
+    // scrolling asks for at most one update per frame
+    const onScroll = () => {
+      if (frame) return;
+
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        update();
+      });
+    };
+
+    // the scrollbar keeps its own strip of the mask, so it is not faded. Its
+    // width only changes with the element, not while scrolling
+    const measureGutter = () => {
+      el.style.setProperty(
+        '--scroll-fade-gutter',
+        `${el.offsetWidth - el.clientWidth}px`
+      );
+    };
+
+    const observer = new ResizeObserver(() => {
+      measureGutter();
+      update();
+    });
+    observer.observe(el);
+
+    const observeChildren = () => {
+      for (const child of el.children) observer.observe(child);
+    };
+
+    // images, translations and query results land after the first render
+    const children = new MutationObserver(() => {
+      observeChildren();
+      update();
+    });
+
+    observeChildren();
+    children.observe(el, { childList: true });
+    el.addEventListener('scroll', onScroll, { passive: true });
+    measureGutter();
+    update();
+
+    cleanup.current = () => {
+      cancelAnimationFrame(frame);
+      el.removeEventListener('scroll', onScroll);
+      observer.disconnect();
+      children.disconnect();
+    };
+  }, []);
+
+  useEffect(() => () => cleanup.current?.(), []);
+
+  return ref;
+};
+
+export default useScrollFade;

--- a/src/hooks/useScrollFade.tsx
+++ b/src/hooks/useScrollFade.tsx
@@ -4,15 +4,11 @@ import { useCallback, useEffect, useRef } from 'react';
 const REVEAL = 8;
 
 /**
- * Reveals the `scroll-fade-y` fades of a scrollable element, by how far its
- * content has scrolled past each edge: none at rest, full once content is
- * hidden.
+ * Reveals the `scroll-fade-y` fades of an element by how far its content has
+ * scrolled past each edge, writing the amounts straight to the CSS variables
+ * the fades read: no re-render, no transition to wait on.
  *
- * The amounts are written straight to the CSS variables the fades read, so
- * scrolling neither re-renders nor waits on a transition.
- *
- * The element is attached through a callback ref: content mounted late, such
- * as a dialog opening or an image arriving, is picked up on its own.
+ * Attached by callback ref, so content that mounts late is picked up.
  */
 const useScrollFade = () => {
   const cleanup = useRef<VoidFunction>(null);
@@ -46,8 +42,7 @@ const useScrollFade = () => {
       });
     };
 
-    // the scrollbar keeps its own strip of the mask, so it is not faded. Its
-    // width only changes with the element, not while scrolling
+    // the scrollbar keeps its own strip of the mask, so it is not faded
     const measureGutter = () => {
       el.style.setProperty(
         '--scroll-fade-gutter',
@@ -59,9 +54,12 @@ const useScrollFade = () => {
       measureGutter();
       update();
     });
-    observer.observe(el);
 
     const observeChildren = () => {
+      // re-observing from scratch drops children that have gone
+      observer.disconnect();
+      observer.observe(el);
+
       for (const child of el.children) observer.observe(child);
     };
 


### PR DESCRIPTION
# Description

Follow-up to #5422, which gave the dialog a pinned title row and a pinned actions row but migrated only a handful of dialogs onto them. This one moves the rest of the app over, so a heading no longer scrolls away, and takes the repetition out of the call sites.

**One header.** 32 dialogs move onto `title`, `description` and `closable`. Each loses the `Box`/`Stack` and pair of `Typography` elements that built its title row, and gains a heading that stays in place while the content scrolls. Pinned headers go from 6 to 34 of the 59 dialogs.

**One padding.** 44 dialogs repeated `sx={{ padding: '24px' }}`, which is what the component applies on its own since #5422. That override is gone from 44 of them: 39 had an `sx` that held nothing else, 5 keep an `sx` without the padding. A dialog now passes a padding only when it wants something other than the standard.

**The measurements become variables.** `--dialog-padding`, `--dialog-gap`, `--dialog-gap-mobile` and `--dialog-header-gap` sit in the global stylesheet, so the numbers behind a dialog are set in one place instead of being spelled out in the component. This also answers the review note on #5422 about raw pixel values.

The net effect is 109 fewer lines across 53 files.

Builds on #5422 and carries its two commits as well, since a pull request from a fork cannot be based on another fork branch. Merge #5422 first and this one narrows to its own commit, `tweak(components): harmonize the dialogs onto one header` — that commit is the whole of this change.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## What is deliberately left

**20 headers stay in the content.** Their titles are not a plain string — an interpolated title, a `Markup` description, or a header that also carries a badge or an icon beside the title. They keep working exactly as before, and each needs a decision rather than a rewrite.

**19 dialogs keep a custom button row** rather than `DialogActions`, so their buttons still scroll with the content. Passing each row through `actions` preserves its layout, but a few of those rows are deliberately arranged differently (the field service group export stacks its buttons vertically with the primary on top), so this belongs in its own change.

**Three dialogs keep a padding of their own:** `report_form_dialog` (`0`, deliberate — its paper is transparent and its content carries its own surfaces), `bible_studies/editor` (`12px 24px`) and `speaker_details` (`16px`).

## How it was done

The migration was mechanical, so it was scripted and then reviewed: a pass that moves a title row into props when the first child is exactly a title, an optional grey description and an optional close button, a pass that pulls a description that follows the title, and a pass that removes the imports the rewrite orphaned. Anything that did not match exactly was skipped rather than guessed at — hence the 20 left behind.

## Testing

Checked by hand in test mode: log out, delete person, What's new, About, Support, Share feedback, reorder groups, publish schedules and the export dialogs, on desktop and at 400px. Headers stay put, descriptions read correctly in the pinned row, buttons stay outside the scroll area, and the padding is unchanged at 24px throughout. `npm run build` and `eslint src` pass with no new warnings, and `tsc` reports exactly the same output as before the change.

The repository has no unit tests and its Cypress spec only loads the page, so none of this is covered automatically.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sws2apps/organized-app/pull/5423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->